### PR TITLE
FSB-5245 add large and xl font sizing to avatars

### DIFF
--- a/lib/Avatar/styles.scss
+++ b/lib/Avatar/styles.scss
@@ -156,6 +156,18 @@ $avatar-pillbox-padding: $typo-size-lead * 0.25 math.div($typo-size-lead, 3) !de
     height: $avatar-size-small;
     font-size: $typo-size-micro;
   }
+
+  .avatar--size-lrg & {
+    font-size: $typo-size-base;
+    width: $avatar-size-large;
+    height: $avatar-size-large;
+  }
+
+  .avatar--size-xlrg & {
+    font-size: 32px;
+    width: $avatar-size-extra-large;
+    height: $avatar-size-extra-large;
+  }
 }
 
 .avatar__image {


### PR DESCRIPTION
### 💬 Description
Large and extra large avatars had no CSS to apply the correct font sizes, this PR adds them in.
