### PR TITLE
Adding focus state to buttonIcon

### DIFF
--- a/lib/src/modules/Button/ButtonIcon/styles/buttonIconBase.scss
+++ b/lib/src/modules/Button/ButtonIcon/styles/buttonIconBase.scss
@@ -1,7 +1,8 @@
 .button-icon {
   @apply p-0 items-center justify-center bg-transparent border-transparent;
 
-  &:hover {
+  &:hover,
+  &:focus {
     @apply bg-neutral-primary/10 text-neutral-20 no-underline;
     .icon {
       path {


### PR DESCRIPTION
As found on this [PR](https://github.com/Bynder/gathercontent-app/pull/5122) .The buttonIcon component does not have a focus state on the mediabar.

I have just added it to be the same as the hover, as this is what is done in mono for the `ButtonIcon`. 
I initially set out to simply remove the `outline-none` tailwind classes from the button-base - as from accessibility perspective we should't really have [hover/focus states the same](https://dockyard.com/blog/2020/04/28/designing-for-accessibility-focus-states) - so it inherits the browser default outline, but I guess that opens a huge can of worms as we appear to have specific focus states within mono etc. 🥫🐛