### PR TITLE
GC-857 - Can we use React refs instead of DOM queries

### DIFF
--- a/lib/src/components/form/FormInput.js
+++ b/lib/src/components/form/FormInput.js
@@ -2,15 +2,10 @@ import * as React from 'react';
 import { Input } from 'lib';
 import { FormContext, statuses } from './Form';
 
-export const FormInput = React.forwardRef(function FormInput(
-  { children, ...rest },
-  ref
-) {
+export function FormInput({ children, ...rest }) {
   const { status } = React.useContext(FormContext);
   const hasFailed = status === statuses.failure;
   const isProcessing = status === statuses.processing;
 
-  return (
-    <Input invalid={hasFailed} disabled={isProcessing} {...rest} ref={ref} />
-  );
-});
+  return <Input invalid={hasFailed} disabled={isProcessing} {...rest} />;
+}

--- a/lib/src/components/form/FormInput.js
+++ b/lib/src/components/form/FormInput.js
@@ -2,10 +2,17 @@ import * as React from 'react';
 import { Input } from 'lib';
 import { FormContext, statuses } from './Form';
 
-export function FormInput({ children, ...rest }) {
+export function FormInput({ children, inputRef, ...rest }) {
   const { status } = React.useContext(FormContext);
   const hasFailed = status === statuses.failure;
   const isProcessing = status === statuses.processing;
 
-  return <Input invalid={hasFailed} disabled={isProcessing} {...rest} />;
+  return (
+    <Input
+      invalid={hasFailed}
+      disabled={isProcessing}
+      inputRef={inputRef}
+      {...rest}
+    />
+  );
 }

--- a/lib/src/components/form/FormInput.js
+++ b/lib/src/components/form/FormInput.js
@@ -2,10 +2,15 @@ import * as React from 'react';
 import { Input } from 'lib';
 import { FormContext, statuses } from './Form';
 
-export function FormInput({ children, ...rest }) {
+export const FormInput = React.forwardRef(function FormInput(
+  { children, ...rest },
+  ref
+) {
   const { status } = React.useContext(FormContext);
   const hasFailed = status === statuses.failure;
   const isProcessing = status === statuses.processing;
 
-  return <Input invalid={hasFailed} disabled={isProcessing} {...rest} />;
-}
+  return (
+    <Input invalid={hasFailed} disabled={isProcessing} {...rest} ref={ref} />
+  );
+});

--- a/lib/src/modules/Button/ButtonLink/ButtonLink.js
+++ b/lib/src/modules/Button/ButtonLink/ButtonLink.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { node, string } from 'prop-types';
 
-function ButtonLink({ children, className, ...rest }) {
+function ButtonLink({ children, className, buttonRef, ...rest }) {
   return (
     <button
       type="button"
       className={`${className} bg-transparent border-0 hover:underline focus:outline-none rounded`}
+      ref={buttonRef}
       {...rest}
     >
       {children}

--- a/lib/src/modules/Button/ButtonLink/ButtonLink.js
+++ b/lib/src/modules/Button/ButtonLink/ButtonLink.js
@@ -1,17 +1,21 @@
 import React from 'react';
 import { node, string } from 'prop-types';
 
-function ButtonLink({ children, className, ...rest }) {
+const ButtonLink = React.forwardRef(function ButtonLink(
+  { children, className, ...rest },
+  ref
+) {
   return (
     <button
       type="button"
       className={`${className} bg-transparent border-0 hover:underline focus:outline-none rounded`}
       {...rest}
+      ref={ref}
     >
       {children}
     </button>
   );
-}
+});
 
 ButtonLink.propTypes = {
   children: node.isRequired,

--- a/lib/src/modules/Button/ButtonLink/ButtonLink.js
+++ b/lib/src/modules/Button/ButtonLink/ButtonLink.js
@@ -1,21 +1,17 @@
 import React from 'react';
 import { node, string } from 'prop-types';
 
-const ButtonLink = React.forwardRef(function ButtonLink(
-  { children, className, ...rest },
-  ref
-) {
+function ButtonLink({ children, className, ...rest }) {
   return (
     <button
       type="button"
       className={`${className} bg-transparent border-0 hover:underline focus:outline-none rounded`}
       {...rest}
-      ref={ref}
     >
       {children}
     </button>
   );
-});
+}
 
 ButtonLink.propTypes = {
   children: node.isRequired,

--- a/lib/src/modules/input/Input.js
+++ b/lib/src/modules/input/Input.js
@@ -3,17 +3,20 @@ import { bool, func, string } from 'prop-types';
 import cx from 'classnames';
 import { InputHelper } from './InputHelper';
 
-export function Input({
-  id,
-  className = '',
-  valid,
-  invalid,
-  enhanceNativeSupport,
-  size,
-  value,
-  onChange,
-  ...rest
-}) {
+export const Input = React.forwardRef(function Input(
+  {
+    id,
+    className = '',
+    valid,
+    invalid,
+    enhanceNativeSupport,
+    size,
+    value,
+    onChange,
+    ...rest
+  },
+  ref
+) {
   const [_value, setValue] = React.useState(value);
 
   const classNames = cx(`input input-${size}`, className, {
@@ -35,10 +38,11 @@ export function Input({
         onChange(e);
         setValue(e.target.value);
       }}
+      ref={ref}
       {...rest}
     />
   );
-}
+});
 
 Input.Helper = InputHelper;
 

--- a/lib/src/modules/input/Input.js
+++ b/lib/src/modules/input/Input.js
@@ -12,6 +12,7 @@ export function Input({
   size,
   value,
   onChange,
+  inputRef,
   ...rest
 }) {
   const [_value, setValue] = React.useState(value);
@@ -35,6 +36,7 @@ export function Input({
         onChange(e);
         setValue(e.target.value);
       }}
+      ref={inputRef}
       {...rest}
     />
   );

--- a/lib/src/modules/input/Input.js
+++ b/lib/src/modules/input/Input.js
@@ -3,20 +3,17 @@ import { bool, func, string } from 'prop-types';
 import cx from 'classnames';
 import { InputHelper } from './InputHelper';
 
-export const Input = React.forwardRef(function Input(
-  {
-    id,
-    className = '',
-    valid,
-    invalid,
-    enhanceNativeSupport,
-    size,
-    value,
-    onChange,
-    ...rest
-  },
-  ref
-) {
+export function Input({
+  id,
+  className = '',
+  valid,
+  invalid,
+  enhanceNativeSupport,
+  size,
+  value,
+  onChange,
+  ...rest
+}) {
   const [_value, setValue] = React.useState(value);
 
   const classNames = cx(`input input-${size}`, className, {
@@ -38,11 +35,10 @@ export const Input = React.forwardRef(function Input(
         onChange(e);
         setValue(e.target.value);
       }}
-      ref={ref}
       {...rest}
     />
   );
-});
+}
 
 Input.Helper = InputHelper;
 


### PR DESCRIPTION
### 💬 Description
As part of GC-857 we need to swap dom queries for ref hooks for best practice. Problem is, we don't have access to the refs from within gather-ui so we need to expose the refs via prop drilling.

We tried react's forwardRefs but it seems a little over-engineered for this small task.
### 🔗 Links
[_Links that relate to the PR (Trello, Figma etc.)_](https://bynder.atlassian.net/browse/GC-857)
### 📹 GIF (optional)
_A short GIF of the changes in action._
### 🚪 Start Points
_Where is a good place to start the review? If there are multiple changes it may be worth listing multiple files._
### 👫 Related PRs (optional)
_Any PRs that relate to the changes._
