### PR TITLE
Adding xxs pill

### DIFF
--- a/lib/Pill/PillBase.js
+++ b/lib/Pill/PillBase.js
@@ -5,7 +5,8 @@ import { propTypes, defaultProps, sizes } from './common';
 const PillBase = ({ className, children, size, ...rest }) => {
   const classes = cx(`pill inline-flex items-center rounded ${className}`, {
     'py-1 px-3 text-base': size === sizes.md,
-    'p-1 px-05 text-xs font-semi-bold leading-4': size === sizes.xs
+    'p-1 px-05 text-xs font-semi-bold leading-4': size === sizes.xs,
+    'text-[0.625rem] h-4 px-1': size === sizes.xxs
   });
 
   return (

--- a/lib/Pill/common.js
+++ b/lib/Pill/common.js
@@ -2,7 +2,8 @@ import { node, oneOf, string } from 'prop-types';
 
 export const sizes = {
   md: 'md',
-  xs: 'xs'
+  xs: 'xs',
+  xxs: 'xxs'
 };
 
 export const propTypes = {

--- a/lib/Pill/stories/Pill.stories.js
+++ b/lib/Pill/stories/Pill.stories.js
@@ -36,9 +36,7 @@ export const Pill = () => (
             size={PillComponent.sizes.xxs}
             className="ml-4"
           >
-            <span>
-              Name is <b>David</b>
-            </span>
+            BETA
           </PillComponent>
         </div>
       </StoryItem>

--- a/lib/Pill/stories/Pill.stories.js
+++ b/lib/Pill/stories/Pill.stories.js
@@ -30,6 +30,16 @@ export const Pill = () => (
               Name is <b>David</b>
             </span>
           </PillComponent>
+
+          <PillComponent
+            type={value}
+            size={PillComponent.sizes.xxs}
+            className="ml-4"
+          >
+            <span>
+              Name is <b>David</b>
+            </span>
+          </PillComponent>
         </div>
       </StoryItem>
     ))}


### PR DESCRIPTION
Related to [this PR](https://github.com/Bynder/gathercontent-mono/pull/217) on mono.

Badges and pills seem to be interchangeable on gather-ui, whereas on mono they are separate. Because of this I have had to go with the size `xxs` as `xs` already exists and is in use.
