### PR TITLE
Feature/icon size 24

### DIFF
--- a/lib/Icon/index.js
+++ b/lib/Icon/index.js
@@ -398,7 +398,11 @@ const Icon = props => {
     createClassesFromTypesList(props.textTypes, 'icon__text--')
   );
   return (
-    <span className={`icon icon--${props.name} ${classNames}`}>
+    <span
+      className={`icon icon--${props.name} icon-container-${
+        props.containerSize
+      } ${classNames}`}
+    >
       {props.notification && (
         <span className="icon__notification">{props.notification}</span>
       )}
@@ -421,7 +425,8 @@ Icon.defaultProps = {
   textTypes: [],
   title: null,
   defaultFillColor: true,
-  defaultActiveColor: true
+  defaultActiveColor: true,
+  containerSize: '24'
 };
 
 Icon.propTypes = {
@@ -434,7 +439,8 @@ Icon.propTypes = {
   textTypes: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string,
   defaultFillColor: PropTypes.bool,
-  defaultActiveColor: PropTypes.bool
+  defaultActiveColor: PropTypes.bool,
+  containerSize: PropTypes.string
 };
 
 export default Icon;

--- a/lib/Icon/styles.scss
+++ b/lib/Icon/styles.scss
@@ -1,7 +1,7 @@
 /* ==========================================================================
    Config
    ========================================================================== */
-$icon-display: inline-block !default;
+$icon-display: inline-flex !default;
 $icon-default-color: #678099 !default;
 $icon-hover-color: $color-brand-green !default;
 $icon-active-color: $color-brand-blue !default;
@@ -10,7 +10,11 @@ $icon-active-color: $color-brand-blue !default;
    Styles
    ========================================================================== */
 .icon {
+  align-items: center;
   display: $icon-display;
+  height: 1.5rem;
+  justify-content: center;
+  width: 1.5rem;
 }
 
 .icon svg {

--- a/lib/Icon/styles.scss
+++ b/lib/Icon/styles.scss
@@ -12,13 +12,32 @@ $icon-active-color: $color-brand-blue !default;
 .icon {
   align-items: center;
   display: $icon-display;
-  height: 1.5rem;
   justify-content: center;
+}
+
+.icon-container-12 {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+.icon-container-16 {
+  width: 1rem;
+  height: 1rem;
+}
+
+.icon-container-24 {
   width: 1.5rem;
+  height: 1.5rem;
+}
+
+.icon-container-32 {
+  width: 2rem;
+  height: 2rem;
 }
 
 .icon svg {
   display: block;
+  max-width: 100%;
 }
 
 .icon--default-fill-color path {


### PR DESCRIPTION
Off the back of [this request](https://bynder.atlassian.net/browse/GC-888). I have introduced the 12,16,24, and 32 size props for the icons, [same as mono](https://main--62852a18d2efc2004a65c901.chromatic.com/?path=/story/icons-icon--icon). 
The default is set to 24, [as per mono](https://main--62852a18d2efc2004a65c901.chromatic.com/?path=/story/icons-icon--icon).