### PR TITLE
remove the text colour from warning icon

### DIFF
--- a/lib/Icon/styles.scss
+++ b/lib/Icon/styles.scss
@@ -152,7 +152,7 @@ $icon-active-color: $color-brand-blue !default;
 }
 
 .icon.icon--warning path {
-  @apply text-yellow-primary fill-current;
+  @apply fill-current;
 }
 
 button:active .icon--blue-on-button-parent-active path {


### PR DESCRIPTION
### 💬 Description
Removing the text colour property from the warning icon CSS, as this allows the correct icon colour to cascade from the parent element.
