### PR TITLE
GC-1351 - I can't see the rename icon on items with a long name

### DIFF
--- a/lib/CollectionsTable/styles.scss
+++ b/lib/CollectionsTable/styles.scss
@@ -115,6 +115,7 @@ $collections-table-cell-min-height: 40px !default;
   .editable-text__wrapper--editing,
   .editable-text__text  {
     width: 100%;
+    max-width: calc(100% - 25px);
   }
 
   .editable-text__wrapper {


### PR DESCRIPTION
📹 https://share.getcloudapp.com/lluX6BNY

Added a max width on the text container so the pencil icon fits.

![Screenshot 2023-07-17 at 10 37 52](https://github.com/Bynder/gathercontent-gather-ui/assets/3248857/ec2bb5f3-c3b1-43ed-ac23-ec037cb15a97)
