### PR TITLE
Adding flex to second child with the addition of the new drag element

### DIFF
--- a/lib/CollectionsTable/styles.scss
+++ b/lib/CollectionsTable/styles.scss
@@ -52,7 +52,7 @@ $collections-table-cell-min-height: 40px !default;
   min-width: 0;
   white-space: nowrap;
 
-  &:first-child {
+  &:nth-child(2) {
     flex-basis: 10%;
 
     @include respond-to-min($screen-md) {


### PR DESCRIPTION
As part of the [new designs](https://www.figma.com/file/bPJSeiwE1tQ8dm2F6MMdkm/Selection?node-id=391%3A11237&mode=dev) the first element is now a drag element, so this flex needs to be applied to the second.