### PR TITLE
:sparkles: Delete existing dist folder on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "babel --extensions '.ts,.tsx' lib/ --out-dir dist/lib && babel tailwind.config.js --out-dir dist && npm run compile:css && npm run legacy:copy-styles && npm run generate-types",
+    "build": "rm -rf dist && babel --extensions '.ts,.tsx' lib/ --out-dir dist/lib && babel tailwind.config.js --out-dir dist && npm run compile:css && npm run legacy:copy-styles && npm run generate-types",
     "compile:css": "ENABLE_PURGE=true parcel build styles/prod.scss && npm run compile:tailwind",
     "compile:tailwind": "tailwind build styles/prod-tailwind.css -o dist/styles/tailwind.css",
     "format:js": "prettier --write \"{lib,tests,stories/webapp}/**/*.js\"",


### PR DESCRIPTION
Fixes the issue you might get when running the build process and typescript is unable to generate new type definitions 