### PR TITLE
closing gap from tooltip

### DIFF
--- a/lib/TooltipWrapper/tippystyles.scss
+++ b/lib/TooltipWrapper/tippystyles.scss
@@ -15,6 +15,7 @@
   line-height: 1.4;
   outline: 0;
   transition-property: transform, visibility, opacity;
+  transform: translateY(7px);
 }
 
 .tippy-box[data-placement^='top'] > .tippy-arrow {

--- a/stories/components/TooltipWrapper.stories.tsx
+++ b/stories/components/TooltipWrapper.stories.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import StoryItem from '../styleguide/StoryItem';
-import TooltipWrapper from '../../lib/TooltipWrapper/index';
+import React from "react";
+import StoryItem from "../styleguide/StoryItem";
+import TooltipWrapper from "../../lib/TooltipWrapper/index";
 
 export default {
-  title: 'Legacy/Tooltip',
+  title: "Legacy/Tooltip",
   component: TooltipWrapper,
   args: {
-    showManual: false
-  }
+    showManual: false,
+  },
 };
 
 export const Tooltip = (args: any) => {


### PR DESCRIPTION
[Selection toolbar tooltips are too far away. (After further inspection, this is true across the app)](https://bynder.atlassian.net/browse/GC-1793)

Closing the gap of the tooltips. There doesn't appear to be a way to do this via the [plugin](https://atomiks.github.io/tippyjs/#placements), so I styled with CSS. Some formatting styles snuck in there too.

![Screenshot 2023-08-16 at 11 22 23](https://github.com/Bynder/gathercontent-gather-ui/assets/3248857/dd0379aa-da07-4a66-898d-03aa8deaddcb)
