### PR TITLE
:bug: Ensure we close hover menus when we're no longer hovering

### DIFF
--- a/lib/Dropdown/DropdownTrigger.tsx
+++ b/lib/Dropdown/DropdownTrigger.tsx
@@ -96,6 +96,7 @@ export function DropdownTrigger({
           {...rest}
           onClick={handleClick}
           onMouseEnter={handleMouseover}
+          onMouseLeave={handleMouseover}
         >
           {children}
           {useSelect && <Icon name="down" />}
@@ -111,6 +112,7 @@ export function DropdownTrigger({
       className={buttonClassNames}
       onClick={handleClick}
       onMouseEnter={handleMouseover}
+      onMouseLeave={handleMouseover}
       ref={triggerBtnRef}
     >
       {children}


### PR DESCRIPTION
### 💬 Description

https://bynder.atlassian.net/browse/GC-2006

We found a bug where the translations menu and the change tone menu for AI transformation options clash. This PR fixes the issue by making sure the menus hide when the mouse is no longer hovering on them. This way, we won't have multiple menus open and they won't overlap.
