### PR TITLE
add the react types package, then fix all the types

### DIFF
--- a/lib/Avatar/AvatarGroup/index.tsx
+++ b/lib/Avatar/AvatarGroup/index.tsx
@@ -76,13 +76,4 @@ AvatarGroup.defaultProps = {
   stacked: true,
 };
 
-AvatarGroup.propTypes = {
-  children: node.isRequired,
-  maximum: number,
-  className: string,
-  small: bool,
-  micro: bool,
-  stacked: bool,
-};
-
 export default AvatarGroup;

--- a/lib/Avatar/AvatarInformation.tsx
+++ b/lib/Avatar/AvatarInformation.tsx
@@ -1,17 +1,20 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function AvatarInformation(props: any) {
-  return <div className={`avatar__information ${props.className}`}>
-    {props.name && <span className="avatar__name">{props.name}</span>}
+  return (
+    <div className={`avatar__information ${props.className}`}>
+      {props.name && <span className="avatar__name">{props.name}</span>}
 
-    {props.email && (
-      <span className="avatar__email" title={props.email}>
-        {props.email}
-      </span>
-    )}
-    {props.actions && <span className="avatar__actions">{props.actions}</span>}
-  </div>
+      {props.email && (
+        <span className="avatar__email" title={props.email}>
+          {props.email}
+        </span>
+      )}
+      {props.actions && (
+        <span className="avatar__actions">{props.actions}</span>
+      )}
+    </div>
+  );
 }
 
 AvatarInformation.defaultProps = {
@@ -19,13 +22,6 @@ AvatarInformation.defaultProps = {
   name: "",
   email: "",
   actions: null,
-};
-
-AvatarInformation.propTypes = {
-  className: PropTypes.string,
-  name: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
-  email: PropTypes.string,
-  actions: PropTypes.node,
 };
 
 export default AvatarInformation;

--- a/lib/BlankSlate/index.tsx
+++ b/lib/BlankSlate/index.tsx
@@ -1,13 +1,5 @@
 import React from "react";
-import {
-  bool,
-  string,
-  oneOfType,
-  arrayOf,
-  node,
-  shape,
-  func,
-} from "prop-types";
+import { bool, string, oneOfType, node, shape, func } from "prop-types";
 import cx from "classnames";
 import BlankSlateSVG from "../../assets/blankstate.svg";
 import BlankSlate2SVG from "../../assets/blankstate-2.svg";
@@ -46,20 +38,6 @@ export function BlankSlate(props: any) {
     </div>
   );
 }
-
-BlankSlate.propTypes = {
-  fixed: bool,
-  fullHeight: bool,
-  slateStyle: string,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  children: oneOfType([arrayOf(node), node, arrayOf(shape()), string]),
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  customSVG: oneOfType([node, shape(), bool, func]),
-  SVGClassName: string,
-  className: string,
-  emoji: string,
-  emojiLabel: string,
-};
 
 BlankSlate.defaultProps = {
   fixed: false,

--- a/lib/BoundaryClickWatcher/index.tsx
+++ b/lib/BoundaryClickWatcher/index.tsx
@@ -62,10 +62,11 @@ interface Props {
   outsideClickEventValidator?: (e?: React.MouseEvent) => boolean;
   children:
     | React.ReactNode
+    | JSX.Element
     | ((
         boundaryIsActive: boolean,
         boundaryIsFocussed: boolean
-      ) => React.ReactNode);
+      ) => React.ReactNode | JSX.Element);
 }
 
 export function BoundaryClickWatcher({

--- a/lib/Breadcrumb/BreadcrumbItem.tsx
+++ b/lib/Breadcrumb/BreadcrumbItem.tsx
@@ -1,17 +1,11 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
-function BreadcrumbItem({
-  children,
-  ...rest
-}: any) {
-  return <div className="breadcrumb__item" {...rest}>
-    {children}
-  </div>
+function BreadcrumbItem({ children, ...rest }: any) {
+  return (
+    <div className="breadcrumb__item" {...rest}>
+      {children}
+    </div>
+  );
 }
-
-BreadcrumbItem.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired
-};
 
 export default BreadcrumbItem;

--- a/lib/Breadcrumb/index.tsx
+++ b/lib/Breadcrumb/index.tsx
@@ -1,17 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import BreadcrumbItem from "./BreadcrumbItem";
 
 export function Breadcrumb({ children, className, ...rest }: any) {
-  return <nav {...rest} className={`breadcrumb ${className}`}>
-    {children}
-  </nav>
+  return (
+    <nav {...rest} className={`breadcrumb ${className}`}>
+      {children}
+    </nav>
+  );
 }
-
-Breadcrumb.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.array]).isRequired,
-  className: PropTypes.string,
-};
 
 Breadcrumb.defaultProps = {
   className: "",

--- a/lib/Button/index.tsx
+++ b/lib/Button/index.tsx
@@ -1,123 +1,62 @@
-import PropTypes from "prop-types";
-import React, { Component } from "react";
+import React, { ButtonHTMLAttributes, useState } from "react";
 import { createClassesFromTypesList } from "../helpers/classes";
 
-/**
- * @usage
- *
- * <Button
- *  types={['clear', 'collapsed']}
- *  clickHandler={() => {}}
- * >
- *   ...text goes here
- * </Button>
- */
-export class Button extends Component {
-  static defaultProps = {
-    types: ["primary"],
-    disableOnClick: false,
-    disabled: false,
-    className: "",
-    isSubmit: false,
-    title: "",
-    clickHandler: () => {},
-    onClick: null,
-    onMouseEnter: () => {},
-    onMouseLeave: () => {},
-    onKeyDown: () => {},
-    id: null,
-  };
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  types?: string[];
+  disableOnClick?: boolean;
+  isSubmit?: boolean;
+  clickHandler?: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}
 
-  static propTypes = {
-    children: PropTypes.node.isRequired,
-    clickHandler: PropTypes.func,
-    onClick: PropTypes.func,
-    onKeyDown: PropTypes.func,
-    types: PropTypes.arrayOf(PropTypes.string),
-    disabled: PropTypes.bool,
-    disableOnClick: PropTypes.bool,
-    className: PropTypes.string,
-    title: PropTypes.string,
-    isSubmit: PropTypes.bool,
-    onMouseEnter: PropTypes.func,
-    onMouseLeave: PropTypes.func,
-    id: PropTypes.string,
-  };
+export function Button({
+  disableOnClick = false,
+  isSubmit = false,
+  onClick,
+  onKeyDown,
+  className = "",
+  clickHandler,
+  children,
+  id,
+  title,
+  onMouseEnter,
+  onMouseLeave,
+  types = ["primary"],
+}: Props) {
+  const [disabledAfterClick, setDisabledAfterClick] = useState(false);
+  const handleOnClick = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    setDisabledAfterClick(disableOnClick);
 
-  constructor() {
-    // @ts-expect-error TS(2554): Expected 1-2 arguments, but got 0.
-    super();
-
-    this.state = {
-      disabled: false,
-    };
-
-    this.handleOnClick = this.handleOnClick.bind(this);
-  }
-
-  handleOnClick(e: any) {
-    // @ts-expect-error TS(2339): Property 'disableOnClick' does not exist on type '... Remove this comment to see the full error message
-    this.setState({ disabled: this.props.disableOnClick });
-
-    // @ts-expect-error TS(2339): Property 'onClick' does not exist on type 'Readonl... Remove this comment to see the full error message
-    if (this.props.onClick) {
-      // @ts-expect-error TS(2339): Property 'onClick' does not exist on type 'Readonl... Remove this comment to see the full error message
-      return this.props.onClick(e);
+    if (onClick) {
+      return onClick(e);
     }
+    if (clickHandler) {
+      return clickHandler(e);
+    }
+    return e;
+  };
 
-    // @ts-expect-error TS(2339): Property 'clickHandler' does not exist on type 'Re... Remove this comment to see the full error message
-    return this.props.clickHandler(e);
-  }
-
-  render() {
-    const {
-      // @ts-expect-error TS(2339): Property 'disabled' does not exist on type 'Readon... Remove this comment to see the full error message
-      disabled,
-      // @ts-expect-error TS(2339): Property 'children' does not exist on type 'Reado... Remove this comment to see the full error message
-      children,
-      // @ts-expect-error TS(2339): Property 'className' does not exist on type 'Reado... Remove this comment to see the full error message
-      className,
-      // @ts-expect-error TS(2339): Property 'isSubmit' does not exist on type 'Readon... Remove this comment to see the full error message
-      isSubmit,
-      // @ts-expect-error TS(2339): Property 'title' does not exist on type 'Readonly<... Remove this comment to see the full error message
-      title,
-      // @ts-expect-error TS(2339): Property 'id' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
-      id,
-      // @ts-expect-error TS(2339): Property 'types' does not exist on type 'Readonly<... Remove this comment to see the full error message
+  const shareProps = {
+    // @ts-expect-error TS(2339): Property 'disabled' does not exist on type 'Readon... Remove this comment to see the full error message
+    disabled: disabled || disabledAfterClick,
+    onClick: handleOnClick,
+    onKeyDown,
+    className: `button ${createClassesFromTypesList(
       types,
-      // @ts-expect-error TS(2339): Property 'onMouseEnter' does not exist on type 'Re... Remove this comment to see the full error message
-      onMouseEnter,
-      // @ts-expect-error TS(2339): Property 'onMouseLeave' does not exist on type 'Re... Remove this comment to see the full error message
-      onMouseLeave,
-      // @ts-expect-error TS(2339): Property 'onKeyDown' does not exist on type 'Reado... Remove this comment to see the full error message
-      onKeyDown,
-    } = this.props;
+      "button--"
+    )} ${className}`,
+    title,
+    id,
+    onMouseEnter,
+    onMouseLeave,
+  };
 
-    const shareProps = {
-      // @ts-expect-error TS(2339): Property 'disabled' does not exist on type 'Readon... Remove this comment to see the full error message
-      disabled: disabled || this.state.disabled,
-      onClick: this.handleOnClick,
-      onKeyDown,
-      className: `button ${createClassesFromTypesList(
-        types,
-        "button--"
-      )} ${className}`,
-      title,
-      id,
-      onMouseEnter,
-      onMouseLeave,
-    };
-
-    return isSubmit ? (
-      <button type="submit" {...shareProps}>
-        {children}
-      </button>
-    ) : (
-      <button type="button" {...shareProps}>
-        {children}
-      </button>
-    );
-  }
+  return (
+    <button type={isSubmit ? "submit" : "button"} {...shareProps}>
+      {children}
+    </button>
+  );
 }
 
 export default Button;

--- a/lib/ButtonGroup/ButtonGroup.tsx
+++ b/lib/ButtonGroup/ButtonGroup.tsx
@@ -1,15 +1,7 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function ButtonGroup({ children }: any) {
-  return <div className="button-group">{children}</div>
+  return <div className="button-group">{children}</div>;
 }
-
-ButtonGroup.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]).isRequired,
-};
 
 export default ButtonGroup;

--- a/lib/CheckToggle/index.tsx
+++ b/lib/CheckToggle/index.tsx
@@ -1,138 +1,95 @@
-import PropTypes from "prop-types";
-import React, { Component } from "react";
+import React, { ReactNode, useState } from "react";
 import cx from "classnames";
 
-export class CheckToggle extends Component {
-  static propTypes = {
-    className: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    checked: PropTypes.bool,
-    clickHandler: PropTypes.func,
-    labelLeft: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    labelRight: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-    displaySmall: PropTypes.bool,
-    displayChecked: PropTypes.bool,
-    spaceBetween: PropTypes.bool,
-    autoToggle: PropTypes.bool,
-    labelSizeLarge: PropTypes.bool,
-    disabled: PropTypes.bool,
-    marginSizeLarge: PropTypes.bool,
-    toggleClasses: PropTypes.string,
+interface Props {
+  labelLeft?: string | ReactNode;
+  labelRight?: string | ReactNode;
+  clickHandler?: () => void;
+  checked?: boolean;
+  className?: string;
+  displaySmall?: boolean;
+  displayChecked?: boolean;
+  autoToggle?: boolean;
+  spaceBetween?: boolean;
+  disabled?: boolean;
+  labelSizeLarge?: boolean;
+  marginSizeLarge?: boolean;
+  toggleClasses?: string;
+  id?: string;
+}
+
+export function CheckToggle({
+  id,
+  labelLeft,
+  labelRight,
+  clickHandler,
+  checked = false,
+  className = "",
+  displaySmall,
+  displayChecked,
+  autoToggle = true,
+  spaceBetween,
+  disabled,
+  labelSizeLarge,
+  marginSizeLarge,
+  toggleClasses = "",
+}: Props) {
+  const [checkedState, setCheckedState] = useState(checked);
+  const onClickHandler = () => {
+    if (clickHandler) {
+      clickHandler();
+    }
+    setCheckedState(!checkedState);
   };
 
-  static defaultProps = {
-    labelLeft: null,
-    labelRight: null,
-    clickHandler() {},
-    checked: false,
-    className: "",
-    displaySmall: false,
-    displayChecked: false,
-    autoToggle: true,
-    spaceBetween: false,
-    disabled: false,
-    labelSizeLarge: false,
-    marginSizeLarge: false,
-    toggleClasses: "",
-  };
+  const isChecked = autoToggle ? checkedState : checked;
 
-  constructor(props: any) {
-    super(props);
+  const wrapperClasses = cx(`toggle-wrapper ${className}`, {
+    "size-small": displaySmall,
+    "is-checked": displayChecked && isChecked,
+    "h-justify-content-space-between": spaceBetween,
+    "margin-large": marginSizeLarge,
+    disabled,
+  });
 
-    this.onClickHandler = this.onClickHandler.bind(this);
+  const switchLabelClasses = cx("toggle-switch__label", {
+    "label-size-large": labelSizeLarge,
+  });
 
-    this.state = {
-      checked: props.checked,
-    };
-  }
+  const wrapperLabelClasses = cx("toggle-wrapper__label", {
+    "label-size-large": labelSizeLarge,
+  });
 
-  onClickHandler() {
-    // @ts-expect-error TS(2339): Property 'clickHandler' does not exist on type 'Re... Remove this comment to see the full error message
-    this.props.clickHandler();
-    // @ts-expect-error TS(2339): Property 'checked' does not exist on type 'Readonl... Remove this comment to see the full error message
-    this.setState((prevState) => ({ checked: !prevState.checked }));
-  }
-
-  render() {
-    const {
-      // @ts-expect-error TS(2339): Property 'labelLeft' does not exist on type 'Reado... Remove this comment to see the full error message
-      labelLeft,
-      // @ts-expect-error TS(2339): Property 'labelRight' does not exist on type 'Read... Remove this comment to see the full error message
-      labelRight,
-      // @ts-expect-error TS(2339): Property 'id' does not exist on type 'Readonly<{}>... Remove this comment to see the full error message
-      id,
-      // @ts-expect-error TS(2339): Property 'className' does not exist on type 'Reado... Remove this comment to see the full error message
-      className,
-      // @ts-expect-error TS(2339): Property 'displaySmall' does not exist on type 'Re... Remove this comment to see the full error message
-      displaySmall,
-      // @ts-expect-error TS(2339): Property 'displayChecked' does not exist on type '... Remove this comment to see the full error message
-      displayChecked,
-      // @ts-expect-error TS(2339): Property 'spaceBetween' does not exist on type 'Re... Remove this comment to see the full error message
-      spaceBetween,
-      // @ts-expect-error TS(2339): Property 'disabled' does not exist on type 'Readon... Remove this comment to see the full error message
-      disabled,
-      // @ts-expect-error TS(2339): Property 'labelSizeLarge' does not exist on type '... Remove this comment to see the full error message
-      labelSizeLarge,
-      // @ts-expect-error TS(2339): Property 'marginSizeLarge' does not exist on type ... Remove this comment to see the full error message
-      marginSizeLarge,
-      // @ts-expect-error TS(2339): Property 'toggleClasses' does not exist on type 'R... Remove this comment to see the full error message
-      toggleClasses,
-    } = this.props;
-
-    // @ts-expect-error TS(2339): Property 'autoToggle' does not exist on type 'Read... Remove this comment to see the full error message
-    const checked = this.props.autoToggle
-      ? // @ts-expect-error TS(2339): Property 'checked' does not exist on type 'Readonl... Remove this comment to see the full error message
-        this.state.checked
-      : // @ts-expect-error TS(2339): Property 'checked' does not exist on type 'Readonl... Remove this comment to see the full error message
-        this.props.checked;
-
-    const wrapperClasses = cx(`toggle-wrapper ${className}`, {
-      "size-small": displaySmall,
-      "is-checked": displayChecked && checked,
-      "h-justify-content-space-between": spaceBetween,
-      "margin-large": marginSizeLarge,
-      disabled,
-    });
-
-    const switchLabelClasses = cx("toggle-switch__label", {
-      "label-size-large": labelSizeLarge,
-    });
-
-    const wrapperLabelClasses = cx("toggle-wrapper__label", {
-      "label-size-large": labelSizeLarge,
-    });
-
-    return (
-      <div className={wrapperClasses}>
-        {labelLeft && (
-          <label htmlFor={id} className={wrapperLabelClasses}>
-            {labelLeft}
-          </label>
-        )}
-        <span className={`toggle-wrapper__inner ${toggleClasses}`}>
-          <input
-            data-testid={id}
-            onChange={this.onClickHandler}
-            checked={checked}
-            type="checkbox"
-            id={id}
-            className="toggle-switch toggle-switch--inline"
-          />
-          {/* prettier-ignore */}
-          <label // eslint-disable-line jsx-a11y/label-has-associated-control
+  return (
+    <div className={wrapperClasses}>
+      {labelLeft && (
+        <label htmlFor={id} className={wrapperLabelClasses}>
+          {labelLeft}
+        </label>
+      )}
+      <span className={`toggle-wrapper__inner ${toggleClasses}`}>
+        <input
+          data-testid={id}
+          onChange={onClickHandler}
+          checked={checked}
+          type="checkbox"
+          id={id}
+          className="toggle-switch toggle-switch--inline"
+        />
+        {/* prettier-ignore */}
+        <label // eslint-disable-line jsx-a11y/label-has-associated-control
             data-label-id
             className={switchLabelClasses}
             htmlFor={id}
           />
-        </span>
-        {labelRight && (
-          <label htmlFor={id} className={wrapperLabelClasses}>
-            {labelRight}
-          </label>
-        )}
-      </div>
-    );
-  }
+      </span>
+      {labelRight && (
+        <label htmlFor={id} className={wrapperLabelClasses}>
+          {labelRight}
+        </label>
+      )}
+    </div>
+  );
 }
 
 export default CheckToggle;

--- a/lib/ColField/ColFieldBody.tsx
+++ b/lib/ColField/ColFieldBody.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from "react";
-import { propTypes, defaultProps } from "./common";
+import { defaultProps } from "./common";
 
 function ColFieldBody({
   children,
@@ -12,8 +12,6 @@ function ColFieldBody({
     </div>
   );
 }
-
-ColFieldBody.propTypes = propTypes;
 
 ColFieldBody.defaultProps = defaultProps;
 

--- a/lib/ColField/ColFieldFooter.tsx
+++ b/lib/ColField/ColFieldFooter.tsx
@@ -1,5 +1,5 @@
 import React, { HTMLAttributes } from "react";
-import { propTypes, defaultProps } from "./common";
+import { defaultProps } from "./common";
 
 function ColFieldFooter({
   children,
@@ -15,8 +15,6 @@ function ColFieldFooter({
     </div>
   );
 }
-
-ColFieldFooter.propTypes = propTypes;
 
 ColFieldFooter.defaultProps = defaultProps;
 

--- a/lib/ColField/common.ts
+++ b/lib/ColField/common.ts
@@ -1,9 +1,5 @@
-import { node, string } from 'prop-types';
+import { string } from 'prop-types';
 
-export const propTypes = {
-  children: node.isRequired,
-  className: string
-};
 
 export const defaultProps = {
   className: ''

--- a/lib/CollectionsTable/CollectionsTableCell.tsx
+++ b/lib/CollectionsTable/CollectionsTableCell.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
-import CollectionsTableCellContent from './CollectionsTableCellContent';
-import { defaultProps, propTypes } from './propTypes';
+import React from "react";
+import cx from "classnames";
+import CollectionsTableCellContent from "./CollectionsTableCellContent";
+import { defaultProps } from "./propTypes";
 
 function CollectionsTableCell({
   children,
@@ -12,8 +11,8 @@ function CollectionsTableCell({
   ...props
 }: any) {
   const classNames = cx(`collections-table__cell ${className}`, {
-    'collections-table__cell--allow-overflow': allowOverflow,
-    'collections-table__cell--align-right': alignRight
+    "collections-table__cell--allow-overflow": allowOverflow,
+    "collections-table__cell--align-right": alignRight,
   });
   return (
     <div className={classNames} {...props} role="cell">
@@ -24,16 +23,10 @@ function CollectionsTableCell({
   );
 }
 
-CollectionsTableCell.propTypes = {
-  ...propTypes,
-  allowOverflow: PropTypes.bool,
-  alignRight: PropTypes.bool
-};
-
 CollectionsTableCell.defaultProps = {
   ...defaultProps,
   allowOverflow: false,
-  alignRight: false
+  alignRight: false,
 };
 
 export default CollectionsTableCell;

--- a/lib/CollectionsTable/CollectionsTableCellContent.tsx
+++ b/lib/CollectionsTable/CollectionsTableCellContent.tsx
@@ -1,27 +1,18 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
-import { defaultProps, propTypes } from './propTypes';
+import React from "react";
+import cx from "classnames";
+import { defaultProps } from "./propTypes";
 
-function CollectionsTableCellContent({
-  children,
-  allowOverflow
-}: any) {
-  const classNames = cx('collections-table__cell-content', {
-    'collections-table__cell-content--allow-overflow': allowOverflow
+function CollectionsTableCellContent({ children, allowOverflow }: any) {
+  const classNames = cx("collections-table__cell-content", {
+    "collections-table__cell-content--allow-overflow": allowOverflow,
   });
 
   return <div className={classNames}>{children}</div>;
 }
 
-CollectionsTableCellContent.propTypes = {
-  ...propTypes,
-  allowOverflow: PropTypes.bool
-};
-
 CollectionsTableCellContent.defaultProps = {
   ...defaultProps,
-  allowOverflow: false
+  allowOverflow: false,
 };
 
 export default CollectionsTableCellContent;

--- a/lib/CollectionsTable/CollectionsTableHead.tsx
+++ b/lib/CollectionsTable/CollectionsTableHead.tsx
@@ -1,17 +1,14 @@
-import React from 'react';
-import { propTypes, defaultProps } from './propTypes';
+import React from "react";
+import { defaultProps } from "./propTypes";
 
-function CollectionsTableHead({
-  children,
-  className,
-  ...props
-}: any) {
-  return <div className={`collections-table__head ${className}`} {...props}>
-    {children}
-  </div>
+function CollectionsTableHead({ children, className, ...props }: any) {
+  return (
+    <div className={`collections-table__head ${className}`} {...props}>
+      {children}
+    </div>
+  );
 }
 
-CollectionsTableHead.propTypes = propTypes;
 CollectionsTableHead.defaultProps = defaultProps;
 
 export default CollectionsTableHead;

--- a/lib/CollectionsTable/CollectionsTableHeading.tsx
+++ b/lib/CollectionsTable/CollectionsTableHeading.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
-import { propTypes, defaultProps } from './propTypes';
-import CollectionsTableCellContent from './CollectionsTableCellContent';
+import React from "react";
+import { defaultProps } from "./propTypes";
+import CollectionsTableCellContent from "./CollectionsTableCellContent";
 
-function CollectionsTableHeading({
-  children,
-  className,
-  ...props
-}: any) {
-  return <div className={`collections-table__heading ${className}`} {...props} role="columnheader">
-    <CollectionsTableCellContent>{children}</CollectionsTableCellContent>
-  </div>
+function CollectionsTableHeading({ children, className, ...props }: any) {
+  return (
+    <div
+      className={`collections-table__heading ${className}`}
+      {...props}
+      role="columnheader"
+    >
+      <CollectionsTableCellContent>{children}</CollectionsTableCellContent>
+    </div>
+  );
 }
 
-CollectionsTableHeading.propTypes = propTypes;
 CollectionsTableHeading.defaultProps = defaultProps;
 
 export default CollectionsTableHeading;

--- a/lib/CollectionsTable/CollectionsTableRow.tsx
+++ b/lib/CollectionsTable/CollectionsTableRow.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
 function CollectionsTableRow({
   children,
@@ -11,9 +10,9 @@ function CollectionsTableRow({
   ...props
 }: any) {
   const classes = cx(`collections-table__row ${className}`, {
-    'collections-table__row--selected': selected,
-    'collections-table__row--disabled': disabled,
-    'collections-table__row--is-over': isOver
+    "collections-table__row--selected": selected,
+    "collections-table__row--disabled": disabled,
+    "collections-table__row--is-over": isOver,
   });
   return (
     <div className={classes} {...props} role="row">
@@ -22,19 +21,11 @@ function CollectionsTableRow({
   );
 }
 
-CollectionsTableRow.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  selected: PropTypes.bool,
-  disabled: PropTypes.bool,
-  isOver: PropTypes.bool
-};
-
 CollectionsTableRow.defaultProps = {
-  className: '',
+  className: "",
   selected: false,
   disabled: false,
-  isOver: false
+  isOver: false,
 };
 
 export default CollectionsTableRow;

--- a/lib/CollectionsTable/index.tsx
+++ b/lib/CollectionsTable/index.tsx
@@ -4,15 +4,16 @@ import CollectionsTableHeading from "./CollectionsTableHeading";
 import CollectionsTableRow from "./CollectionsTableRow";
 import CollectionsTableCell from "./CollectionsTableCell";
 import CollectionsTableCellContent from "./CollectionsTableCellContent";
-import { propTypes, defaultProps } from "./propTypes";
+import { defaultProps } from "./propTypes";
 
 export function CollectionsTable({ children, className, ...props }: any) {
-  return <div className={`collections-table ${className}`} {...props} role="table">
-    {children}
-  </div>
+  return (
+    <div className={`collections-table ${className}`} {...props} role="table">
+      {children}
+    </div>
+  );
 }
 
-CollectionsTable.propTypes = propTypes;
 CollectionsTable.defaultProps = defaultProps;
 
 CollectionsTable.Head = CollectionsTableHead;

--- a/lib/CollectionsTable/propTypes.ts
+++ b/lib/CollectionsTable/propTypes.ts
@@ -1,9 +1,4 @@
-import PropTypes from 'prop-types';
 
-export const propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string
-};
 
 export const defaultProps = {
   className: ''

--- a/lib/Comment/Comment.tsx
+++ b/lib/Comment/Comment.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import cx from "classnames";
-import { node, string } from "prop-types";
 import { CommentBody } from "./CommentBody";
 import { CommentMeta } from "./CommentMeta";
 import { CommentReplyCount } from "./CommentReplyCount";
@@ -27,11 +26,6 @@ function Comment({ children, className, ...rest }: any) {
     </div>
   );
 }
-
-Comment.propTypes = {
-  children: node.isRequired,
-  className: string,
-};
 
 Comment.defaultProps = {
   className: "",

--- a/lib/Comment/CommentActions.tsx
+++ b/lib/Comment/CommentActions.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { func } from "prop-types";
 import { ButtonIcon, Comment } from "lib";
 import Dropdown from "../Dropdown";
 import DropdownActionGroup from "../Dropdown/DropdownActionGroup";
@@ -22,7 +21,6 @@ function CommentActions({ onEditClick, onRemoveClick, className }: any) {
                   active={showContent}
                   size={ButtonIcon.sizes.sm}
                   onClick={toggleShowContent}
-                  // @ts-expect-error
                   title="Edit or delete this comment"
                 />
               )}
@@ -56,11 +54,6 @@ function CommentActions({ onEditClick, onRemoveClick, className }: any) {
     </div>
   ) : null;
 }
-
-CommentActions.propTypes = {
-  onEditClick: func,
-  onRemoveClick: func,
-};
 
 CommentActions.defaultProps = {
   onEditClick: () => {},

--- a/lib/Comment/CommentBody.tsx
+++ b/lib/Comment/CommentBody.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { node, string } from "prop-types";
 import { Comment } from "lib";
 import cx from "classnames";
 
@@ -12,11 +11,6 @@ function CommentBody({ children, className }: any) {
 
   return <div className={classNames}>{children}</div>;
 }
-
-CommentBody.propTypes = {
-  children: node.isRequired,
-  className: string,
-};
 
 CommentBody.defaultProps = {
   className: "",

--- a/lib/Comment/CommentDeleteConfirmation.tsx
+++ b/lib/Comment/CommentDeleteConfirmation.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { func, string } from "prop-types";
 import { Comment } from "lib";
 import ConfirmationOverlay from "../ConfirmationOverlay";
 import BoundaryClickWatcher from "../BoundaryClickWatcher";
@@ -30,13 +29,6 @@ function CommentDeleteConfirmation({
     </BoundaryClickWatcher>
   ) : null;
 }
-
-CommentDeleteConfirmation.propTypes = {
-  onConfirm: func.isRequired,
-  confirmButtonText: string,
-  onCancel: func,
-  failureText: string,
-};
 
 CommentDeleteConfirmation.defaultProps = {
   confirmButtonText: "Delete",

--- a/lib/Comment/CommentFailed.tsx
+++ b/lib/Comment/CommentFailed.tsx
@@ -1,12 +1,5 @@
-import React from 'react';
-import { string } from 'prop-types';
+import React from "react";
 
-export function CommentFailed({
-  errorText
-}: any) {
+export function CommentFailed({ errorText }: any) {
   return <span className="text-red-primary text-sm">{errorText}</span>;
 }
-
-CommentFailed.propTypes = {
-  errorText: string.isRequired
-};

--- a/lib/Comment/CommentForm.tsx
+++ b/lib/Comment/CommentForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, useContext, useEffect } from "react";
-import { arrayOf, bool, func, shape, string } from "prop-types";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'reac... Remove this comment to see the full error message
 import { Mention, MentionsInput } from "react-mentions";
 import cx from "classnames";
@@ -117,59 +116,59 @@ function CommentForm({
     <form onSubmit={handleSubmitWithLoader} className="comment-edit-form">
       <div className={inputWrapperClassNames} ref={inputWrapperRef}>
         <MentionsInput
-            className="edit-comment"
-            value={commentText}
-            onChange={handleChange}
-            onFocus={() => setHasFocus(true)}
-            onBlur={() => setHasFocus(false)}
-            placeholder={placeholder}
-            markup="@[__display__]"
-            autoFocus={autoFocusInput}
-            displayTransform={(id: any, display: any) => `@${display}`}
-            disabled={isSubmitting}
-          >
-            <Mention
-              trigger="@"
-              onAdd={onMention}
-              data={(search: any) => searchForUsers(search)}
-              appendSpaceOnAdd
-              renderSuggestion={(suggestion: any) => (
-                <Avatar url={suggestion.avatar} initials={suggestion.initials}>
-                  <AvatarInformation
-                    email={`@${suggestion.display}`}
-                    name={suggestion.name}
-                  />
-                </Avatar>
-              )}
-            />
-          </MentionsInput>
+          className="edit-comment"
+          value={commentText}
+          onChange={handleChange}
+          onFocus={() => setHasFocus(true)}
+          onBlur={() => setHasFocus(false)}
+          placeholder={placeholder}
+          markup="@[__display__]"
+          autoFocus={autoFocusInput}
+          displayTransform={(id: any, display: any) => `@${display}`}
+          disabled={isSubmitting}
+        >
+          <Mention
+            trigger="@"
+            onAdd={onMention}
+            data={(search: any) => searchForUsers(search)}
+            appendSpaceOnAdd
+            renderSuggestion={(suggestion: any) => (
+              <Avatar url={suggestion.avatar} initials={suggestion.initials}>
+                <AvatarInformation
+                  email={`@${suggestion.display}`}
+                  name={suggestion.name}
+                />
+              </Avatar>
+            )}
+          />
+        </MentionsInput>
 
-          <ShortcutTrigger
-            shortcutKey="Enter"
-            onShortcutTrigger={(e: any) => {
-              if (!hasFocus || !commentText) {
-                return e;
-              }
-              // @ts-expect-error
-              return handleSubmitWithLoader(e);
-            }}
-            withCtrlKey
-          />
-          <ShortcutTrigger
-            shortcutKey="Enter"
-            onShortcutTrigger={(e: any) => {
-              if (!hasFocus || !commentText) {
-                return e;
-              }
-              // @ts-expect-error
-              return handleSubmitWithLoader(e);
-            }}
-            withMetaKey
-          />
-          <ShortcutTrigger
-            shortcutKey="Escape"
-            onShortcutTrigger={handleCancel}
-          />
+        <ShortcutTrigger
+          shortcutKey="Enter"
+          onShortcutTrigger={(e: any) => {
+            if (!hasFocus || !commentText) {
+              return e;
+            }
+            // @ts-expect-error
+            return handleSubmitWithLoader(e);
+          }}
+          withCtrlKey
+        />
+        <ShortcutTrigger
+          shortcutKey="Enter"
+          onShortcutTrigger={(e: any) => {
+            if (!hasFocus || !commentText) {
+              return e;
+            }
+            // @ts-expect-error
+            return handleSubmitWithLoader(e);
+          }}
+          withMetaKey
+        />
+        <ShortcutTrigger
+          shortcutKey="Escape"
+          onShortcutTrigger={handleCancel}
+        />
       </div>
 
       {hasFailed && (
@@ -179,7 +178,6 @@ function CommentForm({
       <div className="mt-2 flex justify-end items-center">
         <ButtonTertiary
           size={ButtonPrimary.sizes.xs}
-          // @ts-expect-error
           disabled={isSubmitting}
           onClick={handleCancel}
           className="mr-2"
@@ -215,20 +213,6 @@ function CommentForm({
     </form>
   );
 }
-
-CommentForm.propTypes = {
-  children: string,
-  onSubmit: func.isRequired,
-  users: arrayOf(shape({})).isRequired,
-  onRowCountChange: func,
-  autoFocusInput: bool,
-  onCancel: func,
-  placeholder: string,
-  onChange: func,
-  submitText: string,
-  onMention: func,
-  submitTooltipText: string,
-};
 
 CommentForm.defaultProps = {
   children: "",

--- a/lib/Comment/CommentHeader.tsx
+++ b/lib/Comment/CommentHeader.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { node, string } from "prop-types";
 import { Comment } from "lib";
 import cx from "classnames";
 
@@ -21,12 +20,6 @@ function CommentHeader({ children, actions, className }: any) {
     </div>
   );
 }
-
-CommentHeader.propTypes = {
-  children: node.isRequired,
-  actions: node,
-  className: string,
-};
 
 CommentHeader.defaultProps = {
   actions: null,

--- a/lib/Comment/CommentMeta.tsx
+++ b/lib/Comment/CommentMeta.tsx
@@ -1,16 +1,9 @@
-import React from 'react';
-import { array, node, oneOfType, string } from 'prop-types';
+import React from "react";
 
-export function CommentMeta({
-  children
-}: any) {
+export function CommentMeta({ children }: any) {
   return (
     <div className="comment-meta flex w-full item items-center">
       <span className="text-sm text-neutral-primary">{children}</span>
     </div>
   );
 }
-
-CommentMeta.propTypes = {
-  children: oneOfType([string, node, array]).isRequired
-};

--- a/lib/Comment/CommentProvider.tsx
+++ b/lib/Comment/CommentProvider.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, useEffect, useState } from 'react';
-import { bool, node } from 'prop-types';
+import React, { createContext, useEffect, useState } from "react";
 
 const CommentContext = createContext({});
 
@@ -9,7 +8,7 @@ function CommentProvider({
   isEditing: editing,
   isDeleting: deleting,
   hasFailed: failed,
-  showBorders
+  showBorders,
 }: any) {
   const [isEditing, setIsEditing] = useState(editing);
   const [isDeleting, setIsDeleting] = useState(deleting);
@@ -35,7 +34,7 @@ function CommentProvider({
     isDeleting,
     setIsDeleting,
     hasFailed,
-    setHasFailed
+    setHasFailed,
   };
 
   return (
@@ -44,21 +43,11 @@ function CommentProvider({
     </CommentContext.Provider>
   );
 }
-
-CommentProvider.propTypes = {
-  children: node.isRequired,
-  isOpen: bool.isRequired,
-  showBorders: bool,
-  isDeleting: bool,
-  isEditing: bool,
-  hasFailed: bool
-};
-
 CommentProvider.defaultProps = {
   isDeleting: false,
   isEditing: false,
   hasFailed: false,
-  showBorders: false
+  showBorders: false,
 };
 
 export { CommentProvider, CommentContext };

--- a/lib/Comment/CommentReplyCount.tsx
+++ b/lib/Comment/CommentReplyCount.tsx
@@ -1,21 +1,14 @@
-import React from 'react';
-import { number } from 'prop-types';
+import React from "react";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'plur... Remove this comment to see the full error message
-import pluralize from 'pluralize';
+import pluralize from "pluralize";
 
-export function CommentReplyCount({
-  count
-}: any) {
+export function CommentReplyCount({ count }: any) {
   return (
     <div className="relative flex items-center px-3 mb-2">
       <p className="text-sm text-neutral-primary font-medium no-wrap pr-2 m-0">
-        +{`${count} more ${pluralize('reply', count)}`}
+        +{`${count} more ${pluralize("reply", count)}`}
       </p>
       <span className="w-full border border-solid border-b-0 border-neutral-90" />
     </div>
   );
 }
-
-CommentReplyCount.propTypes = {
-  count: number.isRequired
-};

--- a/lib/Comment/CommentResolveButton.tsx
+++ b/lib/Comment/CommentResolveButton.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { bool, func } from "prop-types";
 import { ButtonSecondary } from "lib";
 import Icon from "../Icon";
 
@@ -33,13 +32,6 @@ export function CommentResolveButton({
     </div>
   );
 }
-
-CommentResolveButton.propTypes = {
-  resolved: bool,
-  onUndoResolve: func,
-  userCanResolve: bool,
-  onResolve: func,
-};
 
 CommentResolveButton.defaultProps = {
   resolved: false,

--- a/lib/Comment/CommentSubscribeToggle.tsx
+++ b/lib/Comment/CommentSubscribeToggle.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from "react";
-import { bool, func } from "prop-types";
 import { ButtonIcon, ButtonIconDanger, useLoader } from "lib";
 
 export function CommentSubscribeToggle({ onToggle, isSubscribed }: any) {
@@ -19,10 +18,10 @@ export function CommentSubscribeToggle({ onToggle, isSubscribed }: any) {
   const [isSubscribing, onToggleWithLoader] = useLoader(handleSubscribeClick);
 
   useEffect(() => () => {
-      if (setHasFailedTimeout.current !== null) {
-        clearTimeout(setHasFailedTimeout.current);
-      }
-    });
+    if (setHasFailedTimeout.current !== null) {
+      clearTimeout(setHasFailedTimeout.current);
+    }
+  });
 
   const ButtonType = hasFailed ? ButtonIconDanger : ButtonIcon;
 
@@ -32,7 +31,6 @@ export function CommentSubscribeToggle({ onToggle, isSubscribed }: any) {
         name={isSubscribing ? "loader16" : "bell"}
         title="Subscribe to conversation"
         size={ButtonIcon.sizes.sm}
-        // @ts-expect-error
         onClick={onToggleWithLoader}
         active={isSubscribed}
       />
@@ -44,11 +42,6 @@ export function CommentSubscribeToggle({ onToggle, isSubscribed }: any) {
     </div>
   );
 }
-
-CommentSubscribeToggle.propTypes = {
-  onToggle: func,
-  isSubscribed: bool,
-};
 
 CommentSubscribeToggle.defaultProps = {
   onToggle: () => {},

--- a/lib/Comment/CommentText.tsx
+++ b/lib/Comment/CommentText.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { arrayOf, bool, shape, string } from "prop-types";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'link... Remove this comment to see the full error message
 import Linkify from "linkifyjs/react";
 import cx from "classnames";
@@ -75,14 +74,6 @@ function CommentText({
     </div>
   );
 }
-
-CommentText.propTypes = {
-  children: string.isRequired,
-  users: arrayOf(shape({})).isRequired,
-  currentUser: shape({}).isRequired,
-  showFullText: bool,
-  hasBeenEdited: bool,
-};
 
 CommentText.defaultProps = {
   showFullText: true,

--- a/lib/ConfirmationDropdown/ConfirmationDropdownContent.tsx
+++ b/lib/ConfirmationDropdown/ConfirmationDropdownContent.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import PropTypes from "prop-types";
 import Button from "../Button";
 import Icon from "../Icon";
 import TooltipWrapper from "../TooltipWrapper";
@@ -30,12 +29,12 @@ function ConfirmationDropdownContent({
     ? [...sharedButtonProps, "link-danger"]
     : [...sharedButtonProps, "link-default"];
 
-  const { 
-    confirmationPromise, 
-    onPromiseResolve, 
-    onPromiseReject, 
-    dropdownContent, 
-    ...rest 
+  const {
+    confirmationPromise,
+    onPromiseResolve,
+    onPromiseReject,
+    dropdownContent,
+    ...rest
   } = props;
 
   return (
@@ -46,15 +45,13 @@ function ConfirmationDropdownContent({
             {children}
 
             <DropdownFooter data-testid={`${id}-footer`}>
-              {
-                promiseIsPending && (
-                  <Icon
-                    name="loader"
-                    className="confirmation-dropdown__loader"
-                    title="Loading icon"
-                  />  
-                )
-              }
+              {promiseIsPending && (
+                <Icon
+                  name="loader"
+                  className="confirmation-dropdown__loader"
+                  title="Loading icon"
+                />
+              )}
               <TooltipWrapper
                 id="confirmation-dropdown-tooltip"
                 tooltipText={actionTooltip}
@@ -98,22 +95,6 @@ function ConfirmationDropdownContent({
     </DropdownContent>
   );
 }
-
-ConfirmationDropdownContent.propTypes = {
-  id: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-  onConfirm: PropTypes.func.isRequired,
-  onHide: PropTypes.func,
-  isDanger: PropTypes.bool,
-  disabled: PropTypes.bool,
-  hideOnCompletion: PropTypes.bool,
-  promiseIsPending: PropTypes.bool,
-  confirmationText: PropTypes.string,
-  onCancel: PropTypes.func,
-  secondaryAction: PropTypes.node,
-  actionTooltip: PropTypes.string,
-  onCompletion: PropTypes.func.isRequired,
-};
 
 ConfirmationDropdownContent.defaultProps = {
   isDanger: false,

--- a/lib/ConfirmationDropdown/index.tsx
+++ b/lib/ConfirmationDropdown/index.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import Dropdown from "../Dropdown";
 import ConfirmationDropdownContent from "./ConfirmationDropdownContent";
@@ -73,25 +72,6 @@ export class ConfirmationDropdown extends Component {
     );
   }
 }
-
-// @ts-expect-error TS(2339): Property 'propTypes' does not exist on type 'typeo... Remove this comment to see the full error message
-ConfirmationDropdown.propTypes = {
-  id: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-  dropdownContent: PropTypes.node.isRequired,
-  confirmationPromise: PropTypes.func.isRequired,
-  onHide: PropTypes.func,
-  hideOnCompletion: PropTypes.bool,
-  className: PropTypes.string,
-  isDanger: PropTypes.bool,
-  disabled: PropTypes.bool,
-  confirmationText: PropTypes.string,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  position: PropTypes.shape(),
-  onCancel: PropTypes.func,
-  secondaryAction: PropTypes.node,
-  onCompletion: PropTypes.func,
-};
 
 // @ts-expect-error TS(2339): Property 'defaultProps' does not exist on type 'ty... Remove this comment to see the full error message
 ConfirmationDropdown.defaultProps = {

--- a/lib/ConfirmationModal/index.tsx
+++ b/lib/ConfirmationModal/index.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { Form } from '../src/components/form/Form';
-import Button from '../Button';
-import ProgressButton from '../ProgressButton';
-import Modal from '../Modal';
+import React from "react";
+import { Form } from "../src/components/form/Form";
+import Button from "../Button";
+import ProgressButton from "../ProgressButton";
+import Modal from "../Modal";
 
 export function ConfirmationModal({
   title,
@@ -31,7 +30,7 @@ export function ConfirmationModal({
         <Modal.Header text={introText}>{title}</Modal.Header>
         <Modal.Body>{children}</Modal.Body>
         <Modal.Footer text={footerContent}>
-          <Button types={['link']} clickHandler={rest.onHide}>
+          <Button types={["link"]} clickHandler={rest.onHide}>
             {cancelText}
           </Button>
           {extraButtons}
@@ -51,24 +50,8 @@ export function ConfirmationModal({
   );
 }
 
-ConfirmationModal.propTypes = {
-  title: PropTypes.string.isRequired,
-  children: PropTypes.node.isRequired,
-  submitText: PropTypes.string.isRequired,
-  submitCallback: PropTypes.func.isRequired,
-  cancelText: PropTypes.string.isRequired,
-  onHide: PropTypes.func.isRequired,
-  buttonType: PropTypes.string,
-  introText: PropTypes.string,
-  callbackCanExecute: PropTypes.bool,
-  footerContent: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  disabled: PropTypes.bool,
-  showSpinner: PropTypes.bool,
-  useShowSpinnerProp: PropTypes.bool,
-};
-
 ConfirmationModal.defaultProps = {
-  buttonType: 'primary',
+  buttonType: "primary",
   introText: null,
   callbackCanExecute: true,
   footerContent: null,

--- a/lib/ConfirmationOverlay/index.tsx
+++ b/lib/ConfirmationOverlay/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import {
   ButtonPrimary,
@@ -68,15 +67,6 @@ export function ConfirmationOverlay({
     </div>
   );
 }
-
-ConfirmationOverlay.propTypes = {
-  cancel: PropTypes.func.isRequired,
-  confirm: PropTypes.func.isRequired,
-  className: PropTypes.string,
-  confirmationText: PropTypes.string,
-  show: PropTypes.bool,
-  failureText: PropTypes.string,
-};
 
 ConfirmationOverlay.defaultProps = {
   className: "",

--- a/lib/Conversation/Conversation.tsx
+++ b/lib/Conversation/Conversation.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { bool, node, string } from 'prop-types';
-import cx from 'classnames';
-import { ConversationHeader } from './ConversationHeader';
-import { ConversationFooter } from './ConversationFooter';
-import { ConversationBody } from './ConversationBody';
+import React from "react";
+import cx from "classnames";
+import { ConversationHeader } from "./ConversationHeader";
+import { ConversationFooter } from "./ConversationFooter";
+import { ConversationBody } from "./ConversationBody";
 
 function Conversation({
   className,
@@ -13,11 +12,12 @@ function Conversation({
   ...rest
 }: any) {
   const innerClassName = cx(`${className} relative rounded w-full group`, {
-    'shadow-small bg-white': isOpen,
-    'bg-neutral-98 hover:bg-neutral-95 cursor-pointer conversation__inactive': !isOpen,
-    'shadow-button-secondary-focus border border-solid border-blue-primary':
+    "shadow-small bg-white": isOpen,
+    "bg-neutral-98 hover:bg-neutral-95 cursor-pointer conversation__inactive":
+      !isOpen,
+    "shadow-button-secondary-focus border border-solid border-blue-primary":
       !isOpen && isFocussed,
-    'border border-solid border-neutral-90': !isFocussed || isOpen
+    "border border-solid border-neutral-90": !isFocussed || isOpen,
   });
 
   return (
@@ -27,16 +27,9 @@ function Conversation({
   );
 }
 
-Conversation.propTypes = {
-  className: string,
-  children: node.isRequired,
-  isOpen: bool.isRequired,
-  isFocussed: bool
-};
-
 Conversation.defaultProps = {
-  className: '',
-  isFocussed: false
+  className: "",
+  isFocussed: false,
 };
 
 Conversation.Header = ConversationHeader;

--- a/lib/Conversation/ConversationBody.tsx
+++ b/lib/Conversation/ConversationBody.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function ConversationBody({
-  children,
-  className,
-  ...rest
-}: any) {
+export function ConversationBody({ children, className, ...rest }: any) {
   return (
     <div className={className} {...rest}>
       {children}
@@ -13,11 +8,6 @@ export function ConversationBody({
   );
 }
 
-ConversationBody.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 ConversationBody.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Conversation/ConversationFooter.tsx
+++ b/lib/Conversation/ConversationFooter.tsx
@@ -1,23 +1,12 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function ConversationFooter({
-  children,
-  className,
-  ...rest
-}: any) {
+export function ConversationFooter({ children, className, ...rest }: any) {
   return (
     <div className={`conversation-footer p-3 ${className}`} {...rest}>
       {children}
     </div>
   );
 }
-
-ConversationFooter.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 ConversationFooter.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Conversation/ConversationHeader.tsx
+++ b/lib/Conversation/ConversationHeader.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function ConversationHeader({
-  children,
-  className,
-  ...rest
-}: any) {
+export function ConversationHeader({ children, className, ...rest }: any) {
   return (
     <div
       className={`conversation-header flex p-3 border-t-0 border-l-0 border-r-0 border-b border-solid border-neutral-95 ${className}`}
@@ -16,11 +11,6 @@ export function ConversationHeader({
   );
 }
 
-ConversationHeader.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 ConversationHeader.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Conversation/stories/ConversationFooterForStory.tsx
+++ b/lib/Conversation/stories/ConversationFooterForStory.tsx
@@ -15,7 +15,6 @@ function ConversationFooterForStory({ isOpen }: any) {
       <Comment.Provider isEditing isOpen>
         <Comment.Form
           users={mockUsers}
-          // @ts-expect-error
           author={mockUser}
           submitText="Reply"
           placeholder="Reply..."

--- a/lib/Conversation/stories/ConversationHeaderForStory.tsx
+++ b/lib/Conversation/stories/ConversationHeaderForStory.tsx
@@ -31,7 +31,6 @@ function ConversationHeaderForStory({
   return isOpen ? (
     <Conversation.Header>
       <Comment.SubscribeToggle
-        // @ts-expect-error
         id={`${mockConversation.id}-subscribe`}
         isSubscribed={subscribed}
         onToggle={promise}

--- a/lib/ConversationContext/index.tsx
+++ b/lib/ConversationContext/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes, { arrayOf, shape } from "prop-types";
 import { Col, Person, Row } from "lib";
 import { Conversation } from "../Conversation/Conversation";
 import { Comment } from "../Comment/Comment";
@@ -13,69 +12,56 @@ export function ConversationContext({
   resolveConversation,
   users,
 }: any) {
-  return <Row>
-    <Col sm={3} xs={12}>
-      <div className="conversation-context__label">{label}</div>
-    </Col>
-    <Col sm={8} xs={12}>
-      {children && (
-        <div className="conversation-context__context">{children}</div>
-      )}
-      <Conversation isOpen>
-        <Conversation.Header>
-          {userCanResolve && (
-            <Comment.ResolveButton
-              resolved={resolved}
-              onResolve={resolveConversation}
-              userCanResolve
-            />
-          )}
-        </Conversation.Header>
+  return (
+    <Row>
+      <Col sm={3} xs={12}>
+        <div className="conversation-context__label">{label}</div>
+      </Col>
+      <Col sm={8} xs={12}>
+        {children && (
+          <div className="conversation-context__context">{children}</div>
+        )}
+        <Conversation isOpen>
+          <Conversation.Header>
+            {userCanResolve && (
+              <Comment.ResolveButton
+                resolved={resolved}
+                onResolve={resolveConversation}
+                userCanResolve
+              />
+            )}
+          </Conversation.Header>
 
-        <Conversation.Body>
-          {comments.map((comment: any) => (
-            <Comment.Provider isOpen key={comment.id}>
-              <Comment>
-                <Comment.Header>
-                  <Person
-                    collapse
-                    avatarUrl={comment.author?.avatar}
-                    initials={comment.author?.initials}
-                    name={comment.author?.name}
-                    subtitle={<Comment.Meta>{comment.createdAt}</Comment.Meta>}
-                  />
-                </Comment.Header>
+          <Conversation.Body>
+            {comments.map((comment: any) => (
+              <Comment.Provider isOpen key={comment.id}>
+                <Comment>
+                  <Comment.Header>
+                    <Person
+                      collapse
+                      avatarUrl={comment.author?.avatar}
+                      initials={comment.author?.initials}
+                      name={comment.author?.name}
+                      subtitle={
+                        <Comment.Meta>{comment.createdAt}</Comment.Meta>
+                      }
+                    />
+                  </Comment.Header>
 
-                <Comment.Body>
-                  {/* @ts-expect-error TS(2741): Property 'currentUser' is missing in type '{ child... Remove this comment to see the full error message */}
-                  <Comment.Text users={users} showFullText>
-                    {comment.body}
-                  </Comment.Text>
-                </Comment.Body>
-              </Comment>
-            </Comment.Provider>
-          ))}
-        </Conversation.Body>
-      </Conversation>
-    </Col>
-  </Row>
+                  <Comment.Body>
+                    <Comment.Text users={users} showFullText>
+                      {comment.body}
+                    </Comment.Text>
+                  </Comment.Body>
+                </Comment>
+              </Comment.Provider>
+            ))}
+          </Conversation.Body>
+        </Conversation>
+      </Col>
+    </Row>
+  );
 }
-
-ConversationContext.propTypes = {
-  label: PropTypes.string.isRequired,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]),
-  resolved: PropTypes.bool.isRequired,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  comments: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  resolveConversation: PropTypes.func.isRequired,
-  users: arrayOf(shape({})).isRequired,
-  userCanResolve: PropTypes.bool,
-};
 
 ConversationContext.defaultProps = {
   children: null,

--- a/lib/ConversationContext/stories/ConversationContext.stories.tsx
+++ b/lib/ConversationContext/stories/ConversationContext.stories.tsx
@@ -47,7 +47,6 @@ export function ConversationContext() {
       >
         <ConversationContextComponent
           label="A nice label"
-          // @ts-expect-error
           id="123"
           userCanResolve
           comments={mockComments}
@@ -64,7 +63,6 @@ export function ConversationContext() {
       >
         <ConversationContextComponent
           label="A nice label"
-          // @ts-expect-error
           id="123"
           resolved={false}
           userCanResolve

--- a/lib/Counter/index.tsx
+++ b/lib/Counter/index.tsx
@@ -1,24 +1,15 @@
-import React from 'react';
-import { node, string } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-export function Counter({
-  children,
-  className
-}: any) {
+export function Counter({ children, className }: any) {
   const classes = cx(
     className,
-    'counter rounded-small font-semi-bold bg-blue-primary text-white p-px'
+    "counter rounded-small font-semi-bold bg-blue-primary text-white p-px"
   );
 
   return <span className={classes}>{children}</span>;
 }
 
-Counter.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 Counter.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/DismissiblePrompt/index.tsx
+++ b/lib/DismissiblePrompt/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { node, string, func } from "prop-types";
 import Icon from "../Icon";
 import Button from "../Button";
 
@@ -9,23 +8,19 @@ export function DismissiblePrompt({
   className,
   ...rest
 }: any) {
-  return <div {...rest} className={`dismissible-prompt ${className}`}>
-    <div className="dismissible-prompt__children">{children}</div>
-    <Button
-      types={["icon-only", "collapse"]}
-      className="dismissible-prompt__close"
-      onClick={onDismiss}
-    >
-      <Icon name="cross" />
-    </Button>
-  </div>
+  return (
+    <div {...rest} className={`dismissible-prompt ${className}`}>
+      <div className="dismissible-prompt__children">{children}</div>
+      <Button
+        types={["icon-only", "collapse"]}
+        className="dismissible-prompt__close"
+        onClick={onDismiss}
+      >
+        <Icon name="cross" />
+      </Button>
+    </div>
+  );
 }
-
-DismissiblePrompt.propTypes = {
-  children: node.isRequired,
-  className: string,
-  onDismiss: func.isRequired,
-};
 
 DismissiblePrompt.defaultProps = {
   className: "",

--- a/lib/DnD/DndProvider.tsx
+++ b/lib/DnD/DndProvider.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useState } from "react";
 import { DndProvider as DragAndDropProvider } from "react-dnd-cjs";
-import { func, node } from "prop-types";
 import { DragPreview } from "./DragPreview";
 
 export const DndContext = createContext({});
@@ -24,7 +23,6 @@ function DndProvider({ children, backend }: any) {
     <DragAndDropProvider backend={backend}>
       <DndContext.Provider value={sharedState}>
         {isDragging && (preview || failurePreview) && (
-          // @ts-expect-error TS(2322): Type 'null' is not assignable to type 'string | nu... Remove this comment to see the full error message
           <DragPreview>{failurePreview || preview}</DragPreview>
         )}
 
@@ -33,10 +31,5 @@ function DndProvider({ children, backend }: any) {
     </DragAndDropProvider>
   );
 }
-
-DndProvider.propTypes = {
-  children: node.isRequired,
-  backend: func.isRequired,
-};
 
 export { DndProvider };

--- a/lib/DnD/DragLine.tsx
+++ b/lib/DnD/DragLine.tsx
@@ -1,37 +1,30 @@
-import React, { Fragment } from 'react';
-import { string, number } from 'prop-types';
+import React, { Fragment } from "react";
 
-export function DragLine({
-  alignment,
-  offsetPx
-}: any) {
-  return <>
-    <span
-      className="drag-line__ball drag-line__ball-left"
-      style={{
-        [alignment]: `${-5 - offsetPx}px`
-      }}
-    />
-    <span
-      className="drag-line"
-      style={{
-        [alignment]: `${-3 - offsetPx}px`
-      }}
-    />
-    <span
-      className="drag-line__ball drag-line__ball-right"
-      style={{
-        [alignment]: `${-5 - offsetPx}px`
-      }}
-    />
-  </>
+export function DragLine({ alignment, offsetPx }: any) {
+  return (
+    <>
+      <span
+        className="drag-line__ball drag-line__ball-left"
+        style={{
+          [alignment]: `${-5 - offsetPx}px`,
+        }}
+      />
+      <span
+        className="drag-line"
+        style={{
+          [alignment]: `${-3 - offsetPx}px`,
+        }}
+      />
+      <span
+        className="drag-line__ball drag-line__ball-right"
+        style={{
+          [alignment]: `${-5 - offsetPx}px`,
+        }}
+      />
+    </>
+  );
 }
 
-DragLine.propTypes = {
-  alignment: string.isRequired,
-  offsetPx: number
-};
-
 DragLine.defaultProps = {
-  offsetPx: 0
+  offsetPx: 0,
 };

--- a/lib/DnD/DragPreview.tsx
+++ b/lib/DnD/DragPreview.tsx
@@ -1,32 +1,29 @@
-import React from 'react';
-import { node } from 'prop-types';
-import { useDragLayer } from 'react-dnd-cjs';
-import { getItemStyles } from './helpers/getItemStyles';
+import React from "react";
+import { useDragLayer } from "react-dnd-cjs";
+import { getItemStyles } from "./helpers/getItemStyles";
 
-function DragPreview({
-  children
-}: any) {
+function DragPreview({ children }: any) {
   const { initialOffset, currentOffset, clientOffset } = useDragLayer(
-    monitor => ({
+    (monitor) => ({
       item: monitor.getItem(),
       itemType: monitor.getItemType(),
       initialOffset: monitor.getInitialSourceClientOffset(),
       currentOffset: monitor.getSourceClientOffset(),
       isDragging: monitor.isDragging(),
-      clientOffset: monitor.getClientOffset()
+      clientOffset: monitor.getClientOffset(),
     })
   );
 
   return (
     <div
       style={{
-        position: 'fixed',
-        pointerEvents: 'none',
+        position: "fixed",
+        pointerEvents: "none",
         zIndex: 100,
         left: 0,
         top: 0,
-        width: '100%',
-        height: '100%'
+        width: "100%",
+        height: "100%",
       }}
     >
       <div style={getItemStyles(initialOffset, currentOffset, clientOffset)}>
@@ -35,9 +32,5 @@ function DragPreview({
     </div>
   );
 }
-
-DragPreview.propTypes = {
-  children: node.isRequired
-};
 
 export { DragPreview };

--- a/lib/DnD/Draggable.tsx
+++ b/lib/DnD/Draggable.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { func, shape, node } from "prop-types";
 import { DragPreviewImage, useDrag } from "react-dnd-cjs";
 import { getEmptyImage } from "react-dnd-html5-backend-cjs";
 import { DndContext } from "./DndProvider";
@@ -46,16 +45,6 @@ function Draggable({
     </>
   );
 }
-
-Draggable.propTypes = {
-  children: func.isRequired,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  item: shape().isRequired,
-  preview: node,
-  onBeginDrag: func,
-  onEndDrag: func,
-  canDragChecker: func,
-};
 
 Draggable.defaultProps = {
   preview: null,

--- a/lib/DnD/Droppable.ts
+++ b/lib/DnD/Droppable.ts
@@ -1,5 +1,4 @@
 import { useDrop } from "react-dnd-cjs";
-import { func, node } from "prop-types";
 import { useContext } from "react";
 import { DndContext } from "lib";
 import { throttle } from "lodash";
@@ -34,13 +33,6 @@ function Droppable({
 
   return children(collected, defineDropRef);
 }
-
-Droppable.propTypes = {
-  children: func.isRequired,
-  onDrop: func.isRequired,
-  acceptDragTypes: node.isRequired,
-  canDropChecker: func,
-};
 
 Droppable.defaultProps = {
   canDropChecker: () => true,

--- a/lib/DnD/stories/DnD.stories.tsx
+++ b/lib/DnD/stories/DnD.stories.tsx
@@ -12,12 +12,13 @@ export default {
 };
 
 export function DragAndDrop() {
-  return <DndProvider backend={HTML5Backend}>
-    {/* @ts-expect-error TS(2322): Type '{ name: any; }' is not assignable to type 'I... Remove this comment to see the full error message */}
-    <FolderDndMock name={faker.commerce.productName()} />
-    <ItemDndMock>{faker.commerce.productName()}</ItemDndMock>
-    <DndDropNotification />
-  </DndProvider>
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <FolderDndMock name={faker.commerce.productName()} />
+      <ItemDndMock>{faker.commerce.productName()}</ItemDndMock>
+      <DndDropNotification />
+    </DndProvider>
+  );
 }
 
 DragAndDrop.parameters = {

--- a/lib/DnD/stories/DndDropNotification.tsx
+++ b/lib/DnD/stories/DndDropNotification.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { bool, node } from "prop-types";
 import { action } from "@storybook/addon-actions";
 import { Droppable } from "../Droppable";
 import NotificationBar from "../../Notification/bar";
@@ -22,19 +21,11 @@ function Message({ children, canDrop, isOver, isDragging }: any) {
   }
 
   return (
-    // @ts-expect-error TS(2322): Type '{ children: any; level: string; style: { hei... Remove this comment to see the full error message
     <NotificationBar level={level} style={{ height: "200px" }}>
       {children}
     </NotificationBar>
   );
 }
-
-Message.propTypes = {
-  children: node.isRequired,
-  canDrop: bool.isRequired,
-  isOver: bool.isRequired,
-  isDragging: bool.isRequired,
-};
 
 function DndDropNotification() {
   const { isDragging, setFailurePreview }: any = useContext(DndContext);
@@ -51,7 +42,7 @@ function DndDropNotification() {
     <Droppable
       acceptDragTypes={["item", "folder"]}
       onDrop={action("something was dropped")}
-      canDropChecker={({ type }, monitor) => {
+      canDropChecker={({ type }: any, monitor: any) => {
         const typeIsItem = type === "item";
 
         if (!typeIsItem) {
@@ -65,7 +56,7 @@ function DndDropNotification() {
         return typeIsItem;
       }}
     >
-      {({ canDrop, isOver }, defineDropRef) => (
+      {({ canDrop, isOver }: any, defineDropRef: any) => (
         <div ref={defineDropRef} className="h-margin-top">
           <Message isDragging={isDragging} isOver={isOver} canDrop={canDrop}>
             {(!isDragging || (!canDrop && !isOver)) &&

--- a/lib/DnD/stories/FolderDndMock.tsx
+++ b/lib/DnD/stories/FolderDndMock.tsx
@@ -4,7 +4,6 @@ import { Draggable } from "../Draggable";
 
 function FolderDndMock({ name }: any) {
   const preview = (
-    // @ts-expect-error TS(2322): Type '{ children: () => Element; style: { maxWidth... Remove this comment to see the full error message
     <FolderRow style={{ maxWidth: "300px" }}>
       {() => (
         <>
@@ -22,10 +21,9 @@ function FolderDndMock({ name }: any) {
 
   return (
     <Draggable item={{ type: "folder" }} preview={preview}>
-      {({ isDragging }, dragRef) => (
+      {({ isDragging }: any, dragRef: any) => (
         <div ref={dragRef}>
           <FolderRow
-            // @ts-expect-error TS(2322): Type '{ children: () => Element; style: { opacity:... Remove this comment to see the full error message
             style={{
               opacity: isDragging ? ".5" : "1",
             }}
@@ -47,7 +45,5 @@ function FolderDndMock({ name }: any) {
     </Draggable>
   );
 }
-
-FolderDndMock.propTypes = FolderRow.propTypes;
 
 export { FolderDndMock };

--- a/lib/DnD/stories/ItemDndMock.tsx
+++ b/lib/DnD/stories/ItemDndMock.tsx
@@ -11,7 +11,7 @@ function ItemDndMock({ children }: any) {
 
   return (
     <Draggable item={{ type: "item" }} preview={preview}>
-      {({ isDragging }, dragRef) => (
+      {({ isDragging }: any, dragRef: any) => (
         <div ref={dragRef}>
           <ItemRow
             bordered

--- a/lib/Dropdown/.types/DropdownTypes.ts
+++ b/lib/Dropdown/.types/DropdownTypes.ts
@@ -19,5 +19,5 @@ export interface DropdownProps extends Omit<HTMLAttributes<HTMLDivElement>, "chi
   autoPosition: boolean;
   block: boolean;
   persistShow: boolean;
-  children: ReactNode | ((renderProps: RenderProps) => ReactNode);
+  children: ReactNode | JSX.Element | ((renderProps: RenderProps) => ReactNode | JSX.Element);
 }

--- a/lib/Dropdown/DropdownContent.tsx
+++ b/lib/Dropdown/DropdownContent.tsx
@@ -21,7 +21,10 @@ interface Props extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
   noBorder?: boolean;
   autoPositionLeft?: boolean;
   noTransform?: boolean;
-  children: React.ReactNode | ((showContent: boolean) => React.ReactNode);
+  children:
+    | React.ReactNode
+    | JSX.Element
+    | ((showContent: boolean) => React.ReactNode | JSX.Element);
 }
 
 export function DropdownContent({

--- a/lib/Dropdown/DropdownTrigger.tsx
+++ b/lib/Dropdown/DropdownTrigger.tsx
@@ -24,7 +24,10 @@ interface Props
     arg: boolean,
     arg2: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => {};
-  children: React.ReactNode | ((renderProps: RenderProps) => React.ReactNode);
+  children:
+    | React.ReactNode
+    | JSX.Element
+    | ((renderProps: RenderProps) => React.ReactNode | JSX.Element);
 }
 
 export function DropdownTrigger({

--- a/lib/DueDatePicker/DueDateButton.tsx
+++ b/lib/DueDatePicker/DueDateButton.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import moment from "moment";
 import cx from "classnames";
 import Icon from "../Icon";
@@ -53,14 +52,6 @@ function DueDateButton({ children, ...props }: any) {
     </span>
   );
 }
-
-DueDateButton.propTypes = {
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  dueDate: PropTypes.shape(),
-  children: PropTypes.string,
-  userCanSetDueDate: PropTypes.bool.isRequired,
-  types: PropTypes.arrayOf(PropTypes.string),
-};
 
 DueDateButton.defaultProps = {
   dueDate: null,

--- a/lib/DueDatePicker/DueDateHeader.tsx
+++ b/lib/DueDatePicker/DueDateHeader.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import moment from 'moment';
-import cx from 'classnames';
-import DueDateTime from './DueDateTime';
-import Dropdown from '../Dropdown';
-import Icon from '../Icon';
+import React from "react";
+import moment from "moment";
+import cx from "classnames";
+import DueDateTime from "./DueDateTime";
+import Dropdown from "../Dropdown";
+import Icon from "../Icon";
 
 function DueDateHeader(props: any) {
   let label = (
@@ -19,18 +18,18 @@ function DueDateHeader(props: any) {
     const day = date
       .set({ hour: props.dueTime.hour(), minute: props.dueTime.minute() })
       .calendar(null, {
-        sameDay: '[Today at]',
-        nextDay: '[Tomorrow at]',
-        nextWeek: 'dddd [at]',
-        lastDay: '[Yesterday at]',
-        lastWeek: '[Last] dddd [at]',
-        sameElse: 'MMMM Do YYYY [at]'
+        sameDay: "[Today at]",
+        nextDay: "[Tomorrow at]",
+        nextWeek: "dddd [at]",
+        lastDay: "[Yesterday at]",
+        lastWeek: "[Last] dddd [at]",
+        sameElse: "MMMM Do YYYY [at]",
       });
 
-    const time = props.dueTime.local().format('LT');
+    const time = props.dueTime.local().format("LT");
 
-    const classes = cx('duedate__header--date', {
-      'color-overdue': date < moment()
+    const classes = cx("duedate__header--date", {
+      "color-overdue": date < moment(),
     });
 
     label = (
@@ -40,8 +39,8 @@ function DueDateHeader(props: any) {
     );
   }
 
-  const dropdownClasses = cx('duedate__remove', {
-    'duedate__remove--not-set': !props.dueDate
+  const dropdownClasses = cx("duedate__remove", {
+    "duedate__remove--not-set": !props.dueDate,
   });
 
   return (
@@ -68,18 +67,9 @@ function DueDateHeader(props: any) {
   );
 }
 
-DueDateHeader.propTypes = {
-  removeDueDate: PropTypes.func.isRequired,
-  setTime: PropTypes.func.isRequired,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  dueDate: PropTypes.shape(),
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  dueTime: PropTypes.shape()
-};
-
 DueDateHeader.defaultProps = {
   dueDate: null,
-  dueTime: null
+  dueTime: null,
 };
 
 export default DueDateHeader;

--- a/lib/DueDatePicker/DueDateLabel.tsx
+++ b/lib/DueDatePicker/DueDateLabel.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import Icon from "../Icon";
 
@@ -26,11 +25,6 @@ export function DueDateLabel({ overdue, children }: any) {
     </div>
   );
 }
-
-DueDateLabel.propTypes = {
-  children: PropTypes.node,
-  overdue: PropTypes.bool,
-};
 
 DueDateLabel.defaultProps = {
   children: null,

--- a/lib/DueDatePicker/DueDateTime.tsx
+++ b/lib/DueDatePicker/DueDateTime.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { MenuItem, Dropdown } from "lib";
 
 function DueDateTime(props: any) {
@@ -52,11 +51,6 @@ function DueDateTime(props: any) {
     </Dropdown>
   );
 }
-
-DueDateTime.propTypes = {
-  setTime: PropTypes.func.isRequired,
-  time: PropTypes.string,
-};
 
 DueDateTime.defaultProps = {
   time: "",

--- a/lib/EditableChoiceInput/index.tsx
+++ b/lib/EditableChoiceInput/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useRef, useEffect } from "react";
-import { string, func, bool, node } from "prop-types";
 import cx from "classnames";
 
 export function EditableChoiceInput({
@@ -72,19 +71,6 @@ export function EditableChoiceInput({
     </div>
   );
 }
-
-EditableChoiceInput.propTypes = {
-  type: string.isRequired,
-  onChange: func.isRequired,
-  className: string,
-  label: string,
-  placeholder: string,
-  readOnly: bool,
-  aside: node,
-  autoFocus: bool,
-  onBlur: func,
-  onFocus: func,
-};
 
 EditableChoiceInput.defaultProps = {
   className: "",

--- a/lib/EditableChoiceInput/stories/EditableChoiceInput.stories.tsx
+++ b/lib/EditableChoiceInput/stories/EditableChoiceInput.stories.tsx
@@ -7,30 +7,30 @@ export default {
 };
 
 export function EditableChoiceInput() {
-  return <div>
-    <StoryItem
-      title="EditableChoiceInputComponent"
-      description="A text input next to a choice input"
-    >
-      {/* @ts-expect-error TS(2741): Property 'onChange' is missing in type '{ type: st... Remove this comment to see the full error message */}
-      <EditableChoiceInputComponent
-        type="radio"
-        label="Prepopulated label"
-        placeholder="Add label text"
-        aside={<div>hello!</div>}
-      />
-    </StoryItem>
-    <StoryItem
-      title="EditableChoiceInputComponent"
-      description="A text input next to a choice input"
-    >
-      {/* @ts-expect-error TS(2741): Property 'onChange' is missing in type '{ type: st... Remove this comment to see the full error message */}
-      <EditableChoiceInputComponent
-        type="checkbox"
-        placeholder="Add label text"
-      />
-    </StoryItem>
-  </div>
+  return (
+    <div>
+      <StoryItem
+        title="EditableChoiceInputComponent"
+        description="A text input next to a choice input"
+      >
+        <EditableChoiceInputComponent
+          type="radio"
+          label="Prepopulated label"
+          placeholder="Add label text"
+          aside={<div>hello!</div>}
+        />
+      </StoryItem>
+      <StoryItem
+        title="EditableChoiceInputComponent"
+        description="A text input next to a choice input"
+      >
+        <EditableChoiceInputComponent
+          type="checkbox"
+          placeholder="Add label text"
+        />
+      </StoryItem>
+    </div>
+  );
 }
 
 EditableChoiceInput.parameters = {

--- a/lib/EventCodeWatcher/index.ts
+++ b/lib/EventCodeWatcher/index.ts
@@ -1,5 +1,4 @@
 import { PureComponent, ReactNode, useEffect } from "react";
-import PropTypes from "prop-types";
 
 
 interface Props {

--- a/lib/FigurePlaceholder/FigurePlaceholder.tsx
+++ b/lib/FigurePlaceholder/FigurePlaceholder.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import FigurePlaceholderSVG from "../../assets/figureplaceholder.svg";
 
 function FigurePlaceholder(props: any) {
@@ -12,10 +11,6 @@ function FigurePlaceholder(props: any) {
     </div>
   );
 }
-
-FigurePlaceholder.propTypes = {
-  svgClassName: PropTypes.string,
-};
 
 FigurePlaceholder.defaultProps = {
   svgClassName: "",

--- a/lib/FinderNavigation/FinderGroup.tsx
+++ b/lib/FinderNavigation/FinderGroup.tsx
@@ -1,34 +1,23 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
-function FinderGroup({
-  className,
-  title,
-  children,
-  meta
-}: any) {
-  return <div className={`finder-group ${className}`}>
-    {(title || meta) && (
-      <div className="finder-group-heading">
-        {title && <span className="finder-group-title">{title}</span>}
-        {!!meta && <div className="finder-group-meta">{meta}</div>}
-      </div>
-    )}
-    {children}
-  </div>
+function FinderGroup({ className, title, children, meta }: any) {
+  return (
+    <div className={`finder-group ${className}`}>
+      {(title || meta) && (
+        <div className="finder-group-heading">
+          {title && <span className="finder-group-title">{title}</span>}
+          {!!meta && <div className="finder-group-meta">{meta}</div>}
+        </div>
+      )}
+      {children}
+    </div>
+  );
 }
 
-FinderGroup.propTypes = {
-  children: PropTypes.node.isRequired,
-  title: PropTypes.string,
-  className: PropTypes.string,
-  meta: PropTypes.node
-};
-
 FinderGroup.defaultProps = {
-  className: '',
-  title: '',
-  meta: null
+  className: "",
+  title: "",
+  meta: null,
 };
 
 export default FinderGroup;

--- a/lib/FinderNavigation/FinderItem.tsx
+++ b/lib/FinderNavigation/FinderItem.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
 function FinderItem({
   className,
@@ -12,10 +11,10 @@ function FinderItem({
   ...rest
 }: any) {
   const classNames = cx(`finder-item ${className}`, {
-    'finder-item-active': active,
-    'finder-item-disabled': disabled,
-    'finder-item-hover-settings': hoverSettings,
-    'finder-item-selected': selected
+    "finder-item-active": active,
+    "finder-item-disabled": disabled,
+    "finder-item-hover-settings": hoverSettings,
+    "finder-item-selected": selected,
   });
 
   return (
@@ -25,21 +24,12 @@ function FinderItem({
   );
 }
 
-FinderItem.propTypes = {
-  children: PropTypes.node.isRequired,
-  active: PropTypes.bool,
-  className: PropTypes.string,
-  hoverSettings: PropTypes.bool,
-  selected: PropTypes.bool,
-  disabled: PropTypes.bool
-};
-
 FinderItem.defaultProps = {
   active: false,
-  className: '',
+  className: "",
   hoverSettings: true,
   selected: false,
-  disabled: false
+  disabled: false,
 };
 
 export default FinderItem;

--- a/lib/FinderNavigation/FinderItemContent.tsx
+++ b/lib/FinderNavigation/FinderItemContent.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 
 function FinderItemContent({
@@ -21,13 +20,6 @@ function FinderItemContent({
     </div>
   );
 }
-
-FinderItemContent.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string,
-  isFolder: PropTypes.bool,
-  hidden: PropTypes.bool,
-};
 
 FinderItemContent.defaultProps = {
   className: "",

--- a/lib/FinderNavigation/FinderItemSettings.tsx
+++ b/lib/FinderNavigation/FinderItemSettings.tsx
@@ -1,20 +1,11 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
-function FinderItemSettings({
-  className,
-  children
-}: any) {
-  return <div className={`finder-item-settings ${className}`}>{children}</div>
+function FinderItemSettings({ className, children }: any) {
+  return <div className={`finder-item-settings ${className}`}>{children}</div>;
 }
 
-FinderItemSettings.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string
-};
-
 FinderItemSettings.defaultProps = {
-  className: ''
+  className: "",
 };
 
 export default FinderItemSettings;

--- a/lib/FinderPanelLayout/FinderPanelLayoutHeader.tsx
+++ b/lib/FinderPanelLayout/FinderPanelLayoutHeader.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useRef, useEffect } from "react";
-import { node, string } from "prop-types";
 import cx from "classnames";
 import { FinderPanelLayoutContext } from "./FinderPanelLayoutProvider";
 
@@ -25,11 +24,6 @@ function FinderPanelLayoutHeader({ children, className }: any) {
     </div>
   );
 }
-
-FinderPanelLayoutHeader.propTypes = {
-  children: node.isRequired,
-  className: string,
-};
 
 FinderPanelLayoutHeader.defaultProps = {
   className: "",

--- a/lib/FinderPanelLayout/FinderPanelLayoutLeft.tsx
+++ b/lib/FinderPanelLayout/FinderPanelLayoutLeft.tsx
@@ -1,26 +1,16 @@
-import React from 'react';
-import { node, string, shape } from 'prop-types';
+import React from "react";
 
-function FinderPanelLayoutLeft({
-  children,
-  className,
-  style
-}: any) {
-  return <div className={`finder-panel-layout__left ${className}`} style={style}>
-    {children}
-  </div>
+function FinderPanelLayoutLeft({ children, className, style }: any) {
+  return (
+    <div className={`finder-panel-layout__left ${className}`} style={style}>
+      {children}
+    </div>
+  );
 }
 
-FinderPanelLayoutLeft.propTypes = {
-  children: node.isRequired,
-  className: string,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  style: shape()
-};
-
 FinderPanelLayoutLeft.defaultProps = {
-  className: '',
-  style: {}
+  className: "",
+  style: {},
 };
 
 export default FinderPanelLayoutLeft;

--- a/lib/FinderPanelLayout/FinderPanelLayoutLeftContent.tsx
+++ b/lib/FinderPanelLayout/FinderPanelLayoutLeftContent.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { node, string } from "prop-types";
 import { FinderPanelLayoutContext } from "./FinderPanelLayoutProvider";
 
 function FinderPanelLayoutLeftContent({ children, className }: any) {
@@ -18,11 +17,6 @@ function FinderPanelLayoutLeftContent({ children, className }: any) {
     </div>
   );
 }
-
-FinderPanelLayoutLeftContent.propTypes = {
-  children: node.isRequired,
-  className: string,
-};
 
 FinderPanelLayoutLeftContent.defaultProps = {
   className: "",

--- a/lib/FinderPanelLayout/FinderPanelLayoutProvider.tsx
+++ b/lib/FinderPanelLayout/FinderPanelLayoutProvider.tsx
@@ -1,17 +1,13 @@
-import React, { useState } from 'react';
-import { node, bool } from 'prop-types';
+import React, { useState } from "react";
 
 export const FinderPanelLayoutContext = React.createContext({});
 
-function FinderPanelLayoutProvider({
-  children,
-  fixed
-}: any) {
+function FinderPanelLayoutProvider({ children, fixed }: any) {
   const [headerHeight, setHeaderHeight] = useState(null);
   const sharedState = {
     headerHeight,
     setHeaderHeight,
-    fixed
+    fixed,
   };
 
   return (
@@ -21,13 +17,8 @@ function FinderPanelLayoutProvider({
   );
 }
 
-FinderPanelLayoutProvider.propTypes = {
-  children: node.isRequired,
-  fixed: bool
-};
-
 FinderPanelLayoutProvider.defaultProps = {
-  fixed: false
+  fixed: false,
 };
 
 export default FinderPanelLayoutProvider;

--- a/lib/FinderPanelLayout/FinderPanelLayoutRight.tsx
+++ b/lib/FinderPanelLayout/FinderPanelLayoutRight.tsx
@@ -1,20 +1,13 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-function FinderPanelLayoutRight({
-  children,
-  className
-}: any) {
-  return <div className={`finder-panel-layout__right ${className}`}>{children}</div>
+function FinderPanelLayoutRight({ children, className }: any) {
+  return (
+    <div className={`finder-panel-layout__right ${className}`}>{children}</div>
+  );
 }
 
-FinderPanelLayoutRight.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 FinderPanelLayoutRight.defaultProps = {
-  className: ''
+  className: "",
 };
 
 export default FinderPanelLayoutRight;

--- a/lib/FinderPanelLayout/index.tsx
+++ b/lib/FinderPanelLayout/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { node, string, bool } from "prop-types";
 import FinderPanelLayoutProvider from "./FinderPanelLayoutProvider";
 import FinderPanelLayoutLeft from "./FinderPanelLayoutLeft";
 import FinderPanelLayoutRight from "./FinderPanelLayoutRight";
@@ -23,12 +22,6 @@ FinderPanelLayout.Right = FinderPanelLayoutRight;
 FinderPanelLayout.Header = FinderPanelLayoutHeader;
 
 FinderPanelLayout.LeftContent = FinderPanelLayoutLeftContent;
-
-FinderPanelLayout.propTypes = {
-  children: node.isRequired,
-  className: string,
-  fixed: bool,
-};
 
 FinderPanelLayout.defaultProps = {
   className: "",

--- a/lib/FolderRow/FolderRow.tsx
+++ b/lib/FolderRow/FolderRow.tsx
@@ -1,13 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { bool, node, string, oneOfType, func } from 'prop-types';
-import cx from 'classnames';
+import React, { useState, useEffect } from "react";
+import cx from "classnames";
 
-function FolderRow({
-  children,
-  open,
-  className,
-  ...rest
-}: any) {
+function FolderRow({ children, open, className, ...rest }: any) {
   const [show, setShow] = useState(open);
 
   useEffect(() => {
@@ -15,7 +9,7 @@ function FolderRow({
   }, [open]);
 
   const classNames = cx(`folder-row ${className}`, {
-    'folder-row--open': show
+    "folder-row--open": show,
   });
 
   return (
@@ -25,15 +19,9 @@ function FolderRow({
   );
 }
 
-FolderRow.propTypes = {
-  children: oneOfType([node, func]).isRequired,
-  className: string,
-  open: bool
-};
-
 FolderRow.defaultProps = {
-  className: '',
-  open: false
+  className: "",
+  open: false,
 };
 
 export { FolderRow };

--- a/lib/FolderRow/FolderRowAction.tsx
+++ b/lib/FolderRow/FolderRowAction.tsx
@@ -1,20 +1,11 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
-function FolderRowAction({
-  children,
-  ...props
-}: any) {
-  return <div className="folder-row__action" {...props}>
-    {children}
-  </div>
+function FolderRowAction({ children, ...props }: any) {
+  return (
+    <div className="folder-row__action" {...props}>
+      {children}
+    </div>
+  );
 }
-
-FolderRowAction.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node)
-  ]).isRequired
-};
 
 export { FolderRowAction };

--- a/lib/FolderRow/FolderRowActions.tsx
+++ b/lib/FolderRow/FolderRowActions.tsx
@@ -1,17 +1,11 @@
-import React from 'react';
-import { node, arrayOf, oneOfType } from 'prop-types';
+import React from "react";
 
-function FolderRowActions({
-  children,
-  ...props
-}: any) {
-  return <div className="folder-row__actions" {...props}>
-    {children}
-  </div>
+function FolderRowActions({ children, ...props }: any) {
+  return (
+    <div className="folder-row__actions" {...props}>
+      {children}
+    </div>
+  );
 }
-
-FolderRowActions.propTypes = {
-  children: oneOfType([node, arrayOf(node)]).isRequired
-};
 
 export { FolderRowActions };

--- a/lib/FolderRow/FolderRowAside.tsx
+++ b/lib/FolderRow/FolderRowAside.tsx
@@ -1,14 +1,7 @@
-import React from 'react';
-import { node } from 'prop-types';
+import React from "react";
 
-function FolderRowAside({
-  children
-}: any) {
+function FolderRowAside({ children }: any) {
   return <div className="folder-row__aside">{children}</div>;
 }
-
-FolderRowAside.propTypes = {
-  children: node.isRequired
-};
 
 export { FolderRowAside };

--- a/lib/FolderRow/FolderRowCell.tsx
+++ b/lib/FolderRow/FolderRowCell.tsx
@@ -1,14 +1,9 @@
-import React from 'react';
-import { bool, node } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-function FolderRowCell({
-  children,
-  meta,
-  ...props
-}: any) {
+function FolderRowCell({ children, meta, ...props }: any) {
   const classNames = cx(`folder-row__cell`, {
-    'folder-row__cell--meta': meta
+    "folder-row__cell--meta": meta,
   });
 
   return (
@@ -18,13 +13,8 @@ function FolderRowCell({
   );
 }
 
-FolderRowCell.propTypes = {
-  children: node.isRequired,
-  meta: bool
-};
-
 FolderRowCell.defaultProps = {
-  meta: false
+  meta: false,
 };
 
 export { FolderRowCell };

--- a/lib/FolderRow/FolderRowContents.tsx
+++ b/lib/FolderRow/FolderRowContents.tsx
@@ -1,15 +1,9 @@
-import React from 'react';
-import { bool, node } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-function FolderRowContents({
-  show,
-  children,
-  highlight,
-  ...rest
-}: any) {
+function FolderRowContents({ show, children, highlight, ...rest }: any) {
   const classNames = cx(`folder-row__contents`, {
-    'folder-row__contents--highlight': highlight
+    "folder-row__contents--highlight": highlight,
   });
 
   return (
@@ -21,16 +15,10 @@ function FolderRowContents({
   );
 }
 
-FolderRowContents.propTypes = {
-  show: bool,
-  highlight: bool,
-  children: node
-};
-
 FolderRowContents.defaultProps = {
   show: true,
   highlight: false,
-  children: null
+  children: null,
 };
 
 export { FolderRowContents };

--- a/lib/FolderRow/FolderRowInner.tsx
+++ b/lib/FolderRow/FolderRowInner.tsx
@@ -1,19 +1,11 @@
-import React from 'react';
-import { node } from 'prop-types';
+import React from "react";
 
-function FolderRowInner({
-  children,
-  ...rest
-}: any) {
+function FolderRowInner({ children, ...rest }: any) {
   return (
     <div className="folder-row__inner" {...rest}>
       {children}
     </div>
   );
 }
-
-FolderRowInner.propTypes = {
-  children: node.isRequired
-};
 
 export { FolderRowInner };

--- a/lib/FolderRow/FolderRowName.tsx
+++ b/lib/FolderRow/FolderRowName.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { bool, func, node } from 'prop-types';
-import Button from '../Button';
-import Icon from '../Icon';
+import React from "react";
+import Button from "../Button";
+import Icon from "../Icon";
 
 function FolderRowName({
   children,
@@ -17,7 +16,7 @@ function FolderRowName({
       {showToggle && (
         <div className="folder-row__toggle h-margin-clear h-margin-right-half">
           <Button
-            types={['icon-only']}
+            types={["icon-only"]}
             onClick={() => {
               setShow(!show);
               handleOnClick();
@@ -29,7 +28,7 @@ function FolderRowName({
         </div>
       )}
       <Icon
-        name={show ? 'folderOpen' : 'folder'}
+        name={show ? "folderOpen" : "folder"}
         className="h-margin-right-half"
       />
       <div className="text-overflow-ellipsis h-margin-clear h-width-100">
@@ -39,19 +38,10 @@ function FolderRowName({
   );
 }
 
-FolderRowName.propTypes = {
-  children: node.isRequired,
-  show: bool.isRequired,
-  setShow: func.isRequired,
-  showToggle: bool,
-  toggleTitle: node,
-  handleOnClick: func
-};
-
 FolderRowName.defaultProps = {
   showToggle: true,
-  toggleTitle: 'toggle the contents',
-  handleOnClick: () => {}
+  toggleTitle: "toggle the contents",
+  handleOnClick: () => {},
 };
 
 export { FolderRowName };

--- a/lib/Form/Checkbox/Input.tsx
+++ b/lib/Form/Checkbox/Input.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
 function Input({
   onChangeHandler,
@@ -9,37 +8,28 @@ function Input({
   checked,
   name,
   value,
-  disabled
+  disabled,
 }: any) {
-  return <input
-    className={`form-radio__input ${className}`}
-    type="checkbox"
-    onChange={onChangeHandler}
-    aria-label={label}
-    id={id}
-    name={name}
-    checked={checked}
-    value={value}
-    disabled={disabled}
-  />
+  return (
+    <input
+      className={`form-radio__input ${className}`}
+      type="checkbox"
+      onChange={onChangeHandler}
+      aria-label={label}
+      id={id}
+      name={name}
+      checked={checked}
+      value={value}
+      disabled={disabled}
+    />
+  );
 }
 
-Input.propTypes = {
-  name: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
-  onChangeHandler: PropTypes.func.isRequired,
-  label: PropTypes.string,
-  className: PropTypes.string,
-  value: PropTypes.string,
-  checked: PropTypes.bool.isRequired,
-  disabled: PropTypes.bool
-};
-
 Input.defaultProps = {
-  label: '',
-  className: '',
-  value: '',
-  disabled: false
+  label: "",
+  className: "",
+  value: "",
+  disabled: false,
 };
 
 export default Input;

--- a/lib/Form/Checkbox/index.tsx
+++ b/lib/Form/Checkbox/index.tsx
@@ -1,17 +1,14 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Label from "../Label";
 import Input from "./Input";
 
 export function Checkbox(props: any) {
-  return <div className="form__choice-element-wrapper">
-    <Input {...props} />
-    <Label {...props} />
-  </div>
+  return (
+    <div className="form__choice-element-wrapper">
+      <Input {...props} />
+      <Label {...props} />
+    </div>
+  );
 }
-
-Checkbox.propTypes = {
-  id: PropTypes.string.isRequired,
-};
 
 export default Checkbox;

--- a/lib/Form/FormFooter.tsx
+++ b/lib/Form/FormFooter.tsx
@@ -1,15 +1,7 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function FormFooter({ children }: any) {
-  return <footer className="form__footer">{children}</footer>
+  return <footer className="form__footer">{children}</footer>;
 }
-
-FormFooter.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.arrayOf(PropTypes.node),
-  ]).isRequired,
-};
 
 export default FormFooter;

--- a/lib/Form/FormGroup.tsx
+++ b/lib/Form/FormGroup.tsx
@@ -1,12 +1,7 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function FormGroup({ children }: any) {
-  return <div className="form-group">{children}</div>
+  return <div className="form-group">{children}</div>;
 }
-
-FormGroup.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export default FormGroup;

--- a/lib/Form/FormInput.tsx
+++ b/lib/Form/FormInput.tsx
@@ -1,118 +1,71 @@
-import React, { Component, Fragment } from "react";
-import PropTypes from "prop-types";
+import React, { useState } from "react";
 import cx from "classnames";
 
-export class FormInput extends Component {
-  static propTypes = {
-    type: PropTypes.string,
-    focusOnMount: PropTypes.bool,
-    value: PropTypes.string,
-    placeholder: PropTypes.string,
-    className: PropTypes.string,
-    onInputChange: PropTypes.func,
-    noBorder: PropTypes.bool,
-    collapse: PropTypes.bool,
-    fullWidth: PropTypes.bool,
-    paddingSmall: PropTypes.bool,
-    hasError: PropTypes.bool,
-    errorMessage: PropTypes.string,
-    disabled: PropTypes.bool,
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+  focusOnMount?: boolean;
+  onInputChange?: (value: string) => void;
+  noBorder?: boolean;
+  paddingSmall?: boolean;
+  fullWidth?: boolean;
+  hasError?: boolean;
+  errorMessage?: string;
+  collapse?: boolean;
+}
+
+export function FormInput({
+  type = "text",
+  focusOnMount,
+  value = "",
+  placeholder,
+  className = "",
+  onInputChange,
+  noBorder,
+  paddingSmall,
+  fullWidth,
+  hasError,
+  errorMessage,
+  disabled,
+  collapse,
+  ...rest
+}: Props) {
+  const [inputValue, setInputValue] = useState(value);
+
+  const handleOnChange = (e: any) => {
+    setInputValue(e.target.value);
+    if (onInputChange) {
+      onInputChange(e.target.value);
+    }
   };
 
-  static defaultProps = {
-    type: "text",
-    focusOnMount: false,
-    value: "",
-    placeholder: "",
-    className: "",
-    onInputChange: () => {},
-    noBorder: false,
-    paddingSmall: false,
-    fullWidth: false,
-    hasError: false,
-    errorMessage: "",
-    disabled: false,
-    collapse: false,
-  };
+  const classNames = cx(`form__input ${className}`, {
+    "form__input--noborder": noBorder,
+    "form__input--full-width": fullWidth,
+    "form__input--padding-small": paddingSmall,
+    "form__input--has-error": hasError,
+    "form__input--display-error": hasError && errorMessage,
+    "form__input--collapse": collapse,
+  });
 
-  constructor(props: any) {
-    // @ts-expect-error TS(2554): Expected 1-2 arguments, but got 0.
-    super();
-    this.state = {
-      value: props.value || "",
-    };
-  }
-
-  handleOnChange = (e: any) => {
-    this.setState({ value: e.target.value });
-    // @ts-expect-error TS(2339): Property 'onInputChange' does not exist on type 'R... Remove this comment to see the full error message
-    this.props.onInputChange(e.target.value);
-  };
-
-  render() {
-    const {
-      // @ts-expect-error TS(2339): Property 'type' does not exist on type 'Readonly<{... Remove this comment to see the full error message
-      type,
-      // @ts-expect-error TS(2339): Property 'className' does not exist on type 'Reado... Remove this comment to see the full error message
-      className,
-      // @ts-expect-error TS(2339): Property 'placeholder' does not exist on type 'Rea... Remove this comment to see the full error message
-      placeholder,
-      // @ts-expect-error TS(2339): Property 'noBorder' does not exist on type 'Readon... Remove this comment to see the full error message
-      noBorder,
-      // @ts-expect-error TS(2339): Property 'focusOnMount' does not exist on type 'Re... Remove this comment to see the full error message
-      focusOnMount,
-      // @ts-expect-error TS(2339): Property 'onInputChange' does not exist on type 'R... Remove this comment to see the full error message
-      onInputChange,
-      // @ts-expect-error TS(2339): Property 'value' does not exist on type 'Readonly<... Remove this comment to see the full error message
-      value,
-      // @ts-expect-error TS(2339): Property 'fullWidth' does not exist on type 'Reado... Remove this comment to see the full error message
-      fullWidth,
-      // @ts-expect-error TS(2339): Property 'paddingSmall' does not exist on type 'Re... Remove this comment to see the full error message
-      paddingSmall,
-      // @ts-expect-error TS(2339): Property 'hasError' does not exist on type 'Readon... Remove this comment to see the full error message
-      hasError,
-      // @ts-expect-error TS(2339): Property 'errorMessage' does not exist on type 'Re... Remove this comment to see the full error message
-      errorMessage,
-      // @ts-expect-error TS(2339): Property 'disabled' does not exist on type 'Readon... Remove this comment to see the full error message
-      disabled,
-      // @ts-expect-error TS(2339): Property 'collapse' does not exist on type 'Readon... Remove this comment to see the full error message
-      collapse,
-      ...rest
-    } = this.props;
-    // @ts-expect-error TS(2339): Property 'value' does not exist on type 'Readonly<... Remove this comment to see the full error message
-    const inputValue = this.state.value;
-
-    const classNames = cx(`form__input ${className}`, {
-      "form__input--noborder": noBorder,
-      "form__input--full-width": fullWidth,
-      "form__input--padding-small": paddingSmall,
-      "form__input--has-error": hasError,
-      "form__input--display-error": hasError && errorMessage,
-      "form__input--collapse": collapse,
-    });
-
-    return (
-      <>
-        <input
-          type={type}
-          value={inputValue}
-          onChange={this.handleOnChange}
-          className={classNames}
-          placeholder={placeholder}
-          // @ts-expect-error TS(2339): Property 'focusOnMount' does not exist on type 'Re... Remove this comment to see the full error message
-          autoFocus={this.props.focusOnMount} // eslint-disable-line jsx-a11y/no-autofocus
-          aria-invalid={hasError}
-          disabled={disabled}
-          {...rest}
-        />
-        {hasError && errorMessage && (
-          <span role="alert" className="form-input__error-message">
-            {errorMessage}
-          </span>
-        )}
-      </>
-    );
-  }
+  return (
+    <>
+      <input
+        type={type}
+        value={inputValue}
+        onChange={handleOnChange}
+        className={classNames}
+        placeholder={placeholder}
+        autoFocus={focusOnMount} // eslint-disable-line jsx-a11y/no-autofocus
+        aria-invalid={hasError}
+        disabled={disabled}
+        {...rest}
+      />
+      {hasError && errorMessage && (
+        <span role="alert" className="form-input__error-message">
+          {errorMessage}
+        </span>
+      )}
+    </>
+  );
 }
 
 export default FormInput;

--- a/lib/Form/Label/index.tsx
+++ b/lib/Form/Label/index.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
 function Label({
   label,
@@ -13,24 +12,24 @@ function Label({
   overrideLabelDefault,
   active,
   disabled,
-  hinted
+  hinted,
 }: any) {
   const labelClasses = cx(`form-checkbox__label ${className}`, {
-    'is-disabled': disabled,
-    'form-checkbox__label--hinted': hinted
+    "is-disabled": disabled,
+    "form-checkbox__label--hinted": hinted,
   });
 
-  const textElementClasses = cx('form-input__text', {
-    'is-highlight': highlight,
-    'is-active': active
+  const textElementClasses = cx("form-input__text", {
+    "is-highlight": highlight,
+    "is-active": active,
   });
 
   const buttonElementClasses = cx({
-    'is-highlight': highlight
+    "is-highlight": highlight,
   });
 
   const handleOnClick = () => {
-    if (typeof overrideLabelDefault === 'function') {
+    if (typeof overrideLabelDefault === "function") {
       overrideLabelDefault();
     }
   };
@@ -59,30 +58,16 @@ function Label({
   );
 }
 
-Label.propTypes = {
-  label: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
-  overrideLabelDefault: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-  labelMouseEnter: PropTypes.func,
-  labelMouseLeave: PropTypes.func,
-  active: PropTypes.bool,
-  subtitle: PropTypes.string,
-  className: PropTypes.string,
-  highlight: PropTypes.bool,
-  disabled: PropTypes.bool,
-  hinted: PropTypes.bool
-};
-
 Label.defaultProps = {
-  subtitle: '',
-  className: '',
+  subtitle: "",
+  className: "",
   highlight: false,
   overrideLabelDefault: false,
   labelMouseEnter: () => {},
   labelMouseLeave: () => {},
   active: false,
   disabled: false,
-  hinted: false
+  hinted: false,
 };
 
 export default Label;

--- a/lib/Form/RadioButton/Input.tsx
+++ b/lib/Form/RadioButton/Input.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
 function Input({
   onChangeHandler,
@@ -9,38 +8,29 @@ function Input({
   checked,
   name,
   value,
-  disabled
+  disabled,
 }: any) {
-  return <input
-    className={`form-radio__input ${className}`}
-    type="radio"
-    onChange={onChangeHandler}
-    aria-label={label}
-    id={id}
-    name={name}
-    value={value}
-    disabled={disabled}
-    checked={checked ?? false}
-  />
+  return (
+    <input
+      className={`form-radio__input ${className}`}
+      type="radio"
+      onChange={onChangeHandler}
+      aria-label={label}
+      id={id}
+      name={name}
+      value={value}
+      disabled={disabled}
+      checked={checked ?? false}
+    />
+  );
 }
 
-Input.propTypes = {
-  name: PropTypes.string.isRequired,
-  id: PropTypes.string.isRequired,
-  onChangeHandler: PropTypes.func.isRequired,
-  className: PropTypes.string,
-  label: PropTypes.string,
-  value: PropTypes.string,
-  checked: PropTypes.bool,
-  disabled: PropTypes.bool
-};
-
 Input.defaultProps = {
-  className: '',
-  value: '',
-  label: '',
+  className: "",
+  value: "",
+  label: "",
   disabled: false,
-  checked: undefined
+  checked: undefined,
 };
 
 export default Input;

--- a/lib/Form/RadioButton/Other.tsx
+++ b/lib/Form/RadioButton/Other.tsx
@@ -1,20 +1,8 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import Input from "./Input";
 import Label from "../Label";
 
 class Other extends Component {
-  static propTypes = {
-    name: PropTypes.string.isRequired,
-    value: PropTypes.string,
-    id: PropTypes.string.isRequired,
-    checked: PropTypes.bool,
-    label: PropTypes.string.isRequired,
-    onChangeHandler: PropTypes.func.isRequired,
-    onTextChangeHandler: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
-  };
-
   static defaultProps = {
     value: "",
     checked: false,
@@ -50,7 +38,6 @@ class Other extends Component {
     if (rest.checked) {
       return (
         <div className="form__choice-element-wrapper">
-          {/* @ts-expect-error TS(2739): Type '{ disabled: any; onChangeHandler: any; child... Remove this comment to see the full error message */}
           <Input
             {...rest}
             disabled={disabled}
@@ -79,7 +66,6 @@ class Other extends Component {
 
     return (
       <div className="form__choice-element-wrapper">
-        {/* @ts-expect-error TS(2739): Type '{ onChangeHandler: any; className: string; d... Remove this comment to see the full error message */}
         <Input
           {...rest}
           onChangeHandler={onChangeHandler}

--- a/lib/Form/RadioButton/index.tsx
+++ b/lib/Form/RadioButton/index.tsx
@@ -1,17 +1,14 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Label from "../Label";
 import Input from "./Input";
 
 export function RadioButton(props: any) {
-  return <div className="form__choice-element-wrapper" key={props.id}>
-    <Input {...props} />
-    <Label {...props} />
-  </div>
+  return (
+    <div className="form__choice-element-wrapper" key={props.id}>
+      <Input {...props} />
+      <Label {...props} />
+    </div>
+  );
 }
-
-RadioButton.propTypes = {
-  id: PropTypes.string.isRequired,
-};
 
 export default RadioButton;

--- a/lib/FormModal/index.tsx
+++ b/lib/FormModal/index.tsx
@@ -5,7 +5,7 @@ import Modal from "../Modal";
 
 interface Props {
   title: string;
-  children: ReactNode;
+  children: ReactNode | JSX.Element;
   submitText: string;
   submitHandler: () => void;
   cancelText: string;

--- a/lib/Guideline/index.tsx
+++ b/lib/Guideline/index.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useRef } from "react";
-import { node, arrayOf, oneOfType, string, func } from "prop-types";
 import cx from "classnames";
 import Button from "../Button";
 
@@ -74,14 +73,6 @@ export function Guideline({ children, title, onToggle, className, dir }: any) {
     </div>
   );
 }
-
-Guideline.propTypes = {
-  children: oneOfType([node, arrayOf(node), string]),
-  title: string.isRequired,
-  onToggle: func,
-  className: string,
-  dir: string,
-};
 
 Guideline.defaultProps = {
   children: "",

--- a/lib/InputConfirmationModal/InputConfirmationModal.tsx
+++ b/lib/InputConfirmationModal/InputConfirmationModal.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { node, string, bool, func, oneOfType } from "prop-types";
 import {
   Modal,
   FormInput,
@@ -72,21 +71,6 @@ export function InputConfirmationModal({
     </Modal.Container>
   );
 }
-
-InputConfirmationModal.propTypes = {
-  onHide: func,
-  show: bool,
-  introTitle: string.isRequired,
-  confirmTitle: string.isRequired,
-  introBody: oneOfType([string, node]).isRequired,
-  confirmBody: oneOfType([string, node]).isRequired,
-  buttonText: string,
-  confirmKeyword: string,
-  onConfirm: func.isRequired,
-  className: string,
-  loading: bool,
-  skipConfirm: bool,
-};
 
 InputConfirmationModal.defaultProps = {
   onHide: () => {},

--- a/lib/InputWithButton/index.tsx
+++ b/lib/InputWithButton/index.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import cx from "classnames";
-import PropTypes from "prop-types";
 import Button from "../Button";
 
 export class InputWithButton extends Component {
@@ -71,18 +70,6 @@ InputWithButton.defaultProps = {
   disabled: false,
   buttonTextAfterClick: null,
   paddingSmall: false,
-};
-
-// @ts-expect-error TS(2339): Property 'propTypes' does not exist on type 'typeo... Remove this comment to see the full error message
-InputWithButton.propTypes = {
-  inputId: PropTypes.string.isRequired,
-  buttonId: PropTypes.string.isRequired,
-  value: PropTypes.string.isRequired,
-  buttonText: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
-  buttonTextAfterClick: PropTypes.string,
-  disabled: PropTypes.bool,
-  paddingSmall: PropTypes.bool,
 };
 
 export default InputWithButton;

--- a/lib/ItemRow/ItemRowAside.tsx
+++ b/lib/ItemRow/ItemRowAside.tsx
@@ -1,19 +1,11 @@
-import React from 'react';
-import { node } from 'prop-types';
+import React from "react";
 
-function ItemRowAside({
-  children,
-  ...rest
-}: any) {
+function ItemRowAside({ children, ...rest }: any) {
   return (
     <div className="item-row__aside" {...rest}>
       {children}
     </div>
   );
 }
-
-ItemRowAside.propTypes = {
-  children: node.isRequired
-};
 
 export { ItemRowAside };

--- a/lib/ItemRow/ItemRowData.tsx
+++ b/lib/ItemRow/ItemRowData.tsx
@@ -1,19 +1,11 @@
-import React from 'react';
-import { node } from 'prop-types';
+import React from "react";
 
-function ItemRowData({
-  children,
-  ...rest
-}: any) {
+function ItemRowData({ children, ...rest }: any) {
   return (
     <div className="item-row__data" {...rest}>
       {children}
     </div>
   );
 }
-
-ItemRowData.propTypes = {
-  children: node.isRequired
-};
 
 export { ItemRowData };

--- a/lib/ItemRow/ItemRowName.tsx
+++ b/lib/ItemRow/ItemRowName.tsx
@@ -1,19 +1,11 @@
-import React from 'react';
-import { node } from 'prop-types';
+import React from "react";
 
-function ItemRowName({
-  children,
-  ...props
-}: any) {
+function ItemRowName({ children, ...props }: any) {
   return (
     <div className="item-row__name" {...props}>
       {children}
     </div>
   );
 }
-
-ItemRowName.propTypes = {
-  children: node.isRequired
-};
 
 export { ItemRowName };

--- a/lib/Layout/Body.tsx
+++ b/lib/Layout/Body.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function Body({
-  children,
-  className,
-  ...rest
-}: any) {
+export function Body({ children, className, ...rest }: any) {
   return (
     <div
       className={`layout-body ql-scroll-container relative w-full flex flex-col flex-1 min-h-0 overflow-y-auto container ${className}`}
@@ -16,11 +11,6 @@ export function Body({
   );
 }
 
-Body.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 Body.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Layout/Footer.tsx
+++ b/lib/Layout/Footer.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { animated, useSpring } from 'react-spring';
+import React from "react";
+import { animated, useSpring } from "react-spring";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'd3-e... Remove this comment to see the full error message
-import * as easings from 'd3-ease';
-import { shape, string } from 'prop-types';
+import * as easings from "d3-ease";
 
 export function Footer({
   children,
@@ -14,8 +13,8 @@ export function Footer({
     ...animatableProperties,
     config: {
       easing: easings.easeCubic,
-      duration: 300
-    }
+      duration: 300,
+    },
   });
 
   return (
@@ -29,12 +28,7 @@ export function Footer({
   );
 }
 
-Footer.propTypes = {
-  className: string,
-  animatableProperties: shape({})
-};
-
 Footer.defaultProps = {
-  className: '',
-  animatableProperties: {}
+  className: "",
+  animatableProperties: {},
 };

--- a/lib/Layout/Header.tsx
+++ b/lib/Layout/Header.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function Header({
-  children,
-  className,
-  ...rest
-}: any) {
+export function Header({ children, className, ...rest }: any) {
   return (
     <header className={`layout-header ${className}`} {...rest}>
       {children}
@@ -13,11 +8,6 @@ export function Header({
   );
 }
 
-Header.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 Header.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Layout/InlineSidebar.tsx
+++ b/lib/Layout/InlineSidebar.tsx
@@ -1,15 +1,9 @@
-import React from 'react';
-import { node, string, bool } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-export function InlineSidebar({
-  children,
-  className,
-  isFinder,
-  ...rest
-}: any) {
+export function InlineSidebar({ children, className, isFinder, ...rest }: any) {
   const classNames = cx(`inline-sidebar ${className}`, {
-    'inline-sidebar-finder': isFinder
+    "inline-sidebar-finder": isFinder,
   });
 
   return (
@@ -19,13 +13,7 @@ export function InlineSidebar({
   );
 }
 
-InlineSidebar.propTypes = {
-  children: node.isRequired,
-  className: string,
-  isFinder: bool
-};
-
 InlineSidebar.defaultProps = {
-  className: '',
-  isFinder: false
+  className: "",
+  isFinder: false,
 };

--- a/lib/Layout/LayoutOverlaySidebar.tsx
+++ b/lib/Layout/LayoutOverlaySidebar.tsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { node, bool, oneOf, string } from 'prop-types';
+import React, { ReactElement } from "react";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'd3-e... Remove this comment to see the full error message
-import * as easings from 'd3-ease';
-import cx from 'classnames';
-import { useTransition, animated } from 'react-spring';
+import * as easings from "d3-ease";
+import cx from "classnames";
+import { useTransition, animated } from "react-spring";
 
 export function LayoutOverlaySidebar({
   children,
@@ -11,57 +10,53 @@ export function LayoutOverlaySidebar({
   direction,
   width,
   className,
-  onTransitionEnd
+  onTransitionEnd,
 }: any) {
   const classNames = cx(
-    'layout-overlay-sidebar',
+    "layout-overlay-sidebar",
     {
-      'border-l border-r-0': direction === 'right',
-      'border-r border-l-0': direction === 'left'
+      "border-l border-r-0": direction === "right",
+      "border-r border-l-0": direction === "left",
     },
-    'border-solid border-neutral-90 border-b-0 border-t-0 h-full bg-white shadow',
+    "border-solid border-neutral-90 border-b-0 border-t-0 h-full bg-white shadow",
     className
   );
 
   const transitions = useTransition(isOpen, null, {
     from: {
-      position: 'absolute',
+      position: "absolute",
       width,
-      [direction]: `-${width}`
+      [direction]: `-${width}`,
     },
     enter: {
-      [direction]: '0'
+      [direction]: "0",
     },
     leave: {
-      [direction]: `-${width}`
+      [direction]: `-${width}`,
     },
     onDestroyed: onTransitionEnd,
     config: {
       easing: easings.easeCubic,
-      duration: 300
-    }
+      duration: 300,
+    },
   });
 
-  return transitions.map(
-    ({ item, key, props }) =>
-      item && (
-        <animated.aside className={classNames} key={key} style={props}>
-          {children}
-        </animated.aside>
-      )
+  return (
+    <>
+      {transitions.map(
+        ({ item, key, props }) =>
+          item && (
+            <animated.aside className={classNames} key={key} style={props}>
+              {children}
+            </animated.aside>
+          )
+      )}
+    </>
   );
 }
 
-LayoutOverlaySidebar.propTypes = {
-  children: node,
-  isOpen: bool,
-  direction: oneOf(['left', 'right']),
-  width: string,
-  className: string
-};
-
 LayoutOverlaySidebar.defaultProps = {
   isOpen: false,
-  width: '25%',
-  direction: 'right'
+  width: "25%",
+  direction: "right",
 };

--- a/lib/Layout/Main.tsx
+++ b/lib/Layout/Main.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function Main({
-  children,
-  className,
-  ...rest
-}: any) {
+export function Main({ children, className, ...rest }: any) {
   return (
     <main
       className={`layout-main overflow-y-hidden overflow-x-hidden flex flex-1 flex-col relative ${className}`}
@@ -16,11 +11,6 @@ export function Main({
   );
 }
 
-Main.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 Main.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Layout/Section.tsx
+++ b/lib/Layout/Section.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-export function Section({
-  children,
-  className,
-  ...rest
-}: any) {
+export function Section({ children, className, ...rest }: any) {
   return (
     <div className={`layout-section ${className}`} {...rest}>
       {children}
@@ -13,11 +8,6 @@ export function Section({
   );
 }
 
-Section.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 Section.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/Layout/SubHeader.tsx
+++ b/lib/Layout/SubHeader.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { useSpring, animated } from 'react-spring';
+import React from "react";
+import { useSpring, animated } from "react-spring";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'd3-e... Remove this comment to see the full error message
-import * as easings from 'd3-ease';
-import { node, string, shape } from 'prop-types';
+import * as easings from "d3-ease";
 
 export function SubHeader({
   children,
@@ -14,8 +13,8 @@ export function SubHeader({
     ...animatableProperties,
     config: {
       easing: easings.easeCubic,
-      duration: 300
-    }
+      duration: 300,
+    },
   });
   return (
     <animated.div
@@ -28,13 +27,7 @@ export function SubHeader({
   );
 }
 
-SubHeader.propTypes = {
-  children: node.isRequired,
-  className: string,
-  animatableProperties: shape({})
-};
-
 SubHeader.defaultProps = {
-  className: '',
-  animatableProperties: {}
+  className: "",
+  animatableProperties: {},
 };

--- a/lib/Layout/index.tsx
+++ b/lib/Layout/index.tsx
@@ -1,26 +1,20 @@
-import React from 'react';
-import { node, string, bool } from 'prop-types';
-import cx from 'classnames';
-import { Body } from './Body';
-import { Footer } from './Footer';
-import { Header } from './Header';
-import { SubHeader } from './SubHeader';
-import { Main } from './Main';
-import { InlineSidebar } from './InlineSidebar';
-import { Section } from './Section';
-import { LayoutOverlaySidebar } from './LayoutOverlaySidebar';
+import React from "react";
+import cx from "classnames";
+import { Body } from "./Body";
+import { Footer } from "./Footer";
+import { Header } from "./Header";
+import { SubHeader } from "./SubHeader";
+import { Main } from "./Main";
+import { InlineSidebar } from "./InlineSidebar";
+import { Section } from "./Section";
+import { LayoutOverlaySidebar } from "./LayoutOverlaySidebar";
 
-function Layout({
-  children,
-  className,
-  fullScreen,
-  ...rest
-}: any) {
+function Layout({ children, className, fullScreen, ...rest }: any) {
   const layoutClassName = cx(
-    'layout flex flex-col overflow-x-hidden',
+    "layout flex flex-col overflow-x-hidden",
     className,
     {
-      'h-screen': fullScreen
+      "h-screen": fullScreen,
     }
   );
 
@@ -31,15 +25,9 @@ function Layout({
   );
 }
 
-Layout.propTypes = {
-  children: node.isRequired,
-  className: string,
-  fullScreen: bool
-};
-
 Layout.defaultProps = {
-  className: '',
-  fullScreen: true
+  className: "",
+  fullScreen: true,
 };
 
 Layout.Header = Header;

--- a/lib/List/ListHead.tsx
+++ b/lib/List/ListHead.tsx
@@ -1,10 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
-function ListHead({
-  title,
-  action
-}: any) {
+function ListHead({ title, action }: any) {
   if (!title && !action) {
     return null;
   }
@@ -21,12 +17,7 @@ function ListHead({
 
 ListHead.defaultProps = {
   title: null,
-  action: null
-};
-
-ListHead.propTypes = {
-  title: PropTypes.string,
-  action: PropTypes.node
+  action: null,
 };
 
 export default ListHead;

--- a/lib/List/ListItem.tsx
+++ b/lib/List/ListItem.tsx
@@ -1,28 +1,13 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import List from "./index";
 import Button from "../Button";
 import Icon from "../Icon";
 
 export class ListItem extends Component {
-  static propTypes = {
-    action: PropTypes.node,
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.arrayOf(PropTypes.node),
-    ]),
-    isCurrent: PropTypes.bool,
-    showSubList: PropTypes.bool,
-    onToggle: PropTypes.func,
-    id: PropTypes.string,
-    collapse: PropTypes.bool,
-  };
-
   static defaultProps = {
     id: "",
     action: null,
-    children: null,
     isCurrent: false,
     collapse: false,
     showSubList: false,

--- a/lib/List/index.tsx
+++ b/lib/List/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import cx from "classnames";
-import PropTypes from "prop-types";
 import ListHead from "./ListHead";
 
 export function List(props: any) {
@@ -39,21 +38,6 @@ List.defaultProps = {
   borderedLeft: false,
   bordered: false,
   subtitle: "",
-};
-
-List.propTypes = {
-  title: PropTypes.string,
-  action: PropTypes.node,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]).isRequired,
-  subtitle: PropTypes.string,
-  borderedRight: PropTypes.bool,
-  borderedLeft: PropTypes.bool,
-  bordered: PropTypes.bool,
 };
 
 export default List;

--- a/lib/LoadingOverlay/index.tsx
+++ b/lib/LoadingOverlay/index.tsx
@@ -1,5 +1,4 @@
 import React, { Fragment } from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import LoadingSVG from "../../assets/loading.svg";
 
@@ -30,13 +29,6 @@ export function LoadingOverlay({
     </div>
   );
 }
-
-LoadingOverlay.propTypes = {
-  fixed: PropTypes.bool,
-  hideSVG: PropTypes.bool,
-  percentageLoaded: PropTypes.number,
-  loadingText: PropTypes.string,
-};
 
 LoadingOverlay.defaultProps = {
   fixed: false,

--- a/lib/Logo/index.tsx
+++ b/lib/Logo/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { string, func, oneOfType } from "prop-types";
 import logoSVG from "../../assets/logo.svg";
 
 /**
@@ -24,11 +23,6 @@ export function Logo(props: any) {
 Logo.defaultProps = {
   url: "",
   alt: "GatherContent Logo",
-};
-
-Logo.propTypes = {
-  url: oneOfType([string, func]),
-  alt: string,
 };
 
 export default Logo;

--- a/lib/Modal/Modal.tsx
+++ b/lib/Modal/Modal.tsx
@@ -1,5 +1,4 @@
 import React, { createContext } from "react";
-import PropTypes from "prop-types";
 import { NewModal } from "lib";
 import cx from "classnames";
 
@@ -48,17 +47,6 @@ Modal.defaultProps = {
   mediaOnly: false,
   collapse: false,
   highlight: false,
-};
-
-Modal.propTypes = {
-  children: PropTypes.node.isRequired,
-  size: PropTypes.string,
-  className: PropTypes.string,
-  overflow: PropTypes.bool,
-  overflowHalf: PropTypes.bool,
-  mediaOnly: PropTypes.bool,
-  collapse: PropTypes.bool,
-  highlight: PropTypes.bool,
 };
 
 export default Modal;

--- a/lib/Modal/ModalBody.tsx
+++ b/lib/Modal/ModalBody.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from "react";
 import { NewModal } from "lib";
 
 interface Props {
-  children: ReactNode;
+  children: ReactNode | JSX.Element;
   className?: string;
 }
 

--- a/lib/Modal/ModalColumn.tsx
+++ b/lib/Modal/ModalColumn.tsx
@@ -1,17 +1,13 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
 function ModalColumn(props: any) {
-  return <div className={`modal__column ${props.className}`}>{props.children}</div>
+  return (
+    <div className={`modal__column ${props.className}`}>{props.children}</div>
+  );
 }
 
 ModalColumn.defaultProps = {
-  className: ''
-};
-
-ModalColumn.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string
+  className: "",
 };
 
 export default ModalColumn;

--- a/lib/Modal/ModalFooter.tsx
+++ b/lib/Modal/ModalFooter.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { node, oneOfType, string, bool } from "prop-types";
 import cx from "classnames";
 import { NewModal } from "lib";
 
@@ -22,13 +21,6 @@ function ModalFooter({
     </NewModal.Footer>
   );
 }
-
-ModalFooter.propTypes = {
-  children: node.isRequired,
-  text: oneOfType([string, node]),
-  spaceBetween: bool,
-  className: string,
-};
 
 ModalFooter.defaultProps = {
   text: null,

--- a/lib/Modal/ModalHeader.tsx
+++ b/lib/Modal/ModalHeader.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import PropTypes from "prop-types";
 import { NewModal } from "lib";
 import { LegacyModalContext } from "./Modal";
 
@@ -17,11 +16,6 @@ function ModalHeader({ children, text, ...rest }: any) {
     </NewModal.Header>
   );
 }
-
-ModalHeader.propTypes = {
-  children: PropTypes.node,
-  text: PropTypes.string,
-};
 
 ModalHeader.defaultProps = {
   children: null,

--- a/lib/Modal/ModalHeaderNavigation.tsx
+++ b/lib/Modal/ModalHeaderNavigation.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { NewModal } from "lib";
-import { node, string } from "prop-types";
 import Navigation from "../Navigation";
 import { LegacyModalContext } from "./Modal";
 
@@ -24,8 +23,3 @@ export function ModalHeaderNavigation({ children, title }: any) {
     </NewModal.Header>
   );
 }
-
-ModalHeaderNavigation.propTypes = {
-  children: node.isRequired,
-  title: string.isRequired,
-};

--- a/lib/Modal/ModalImageHeader.tsx
+++ b/lib/Modal/ModalImageHeader.tsx
@@ -1,22 +1,14 @@
-import React from 'react';
-import { string, number } from 'prop-types';
-import ModalHeader from './ModalHeader';
+import React from "react";
+import ModalHeader from "./ModalHeader";
 
-function ImageHeader({
-  imageUrl,
-  height,
-  ...props
-}: any) {
-  return <ModalHeader
-    className="bg-contain bg-center bg-no-repeat rounded-t"
-    style={{ backgroundImage: `url(${imageUrl})`, height: `${height}px` }}
-    {...props}
-  />
+function ImageHeader({ imageUrl, height, ...props }: any) {
+  return (
+    <ModalHeader
+      className="bg-contain bg-center bg-no-repeat rounded-t"
+      style={{ backgroundImage: `url(${imageUrl})`, height: `${height}px` }}
+      {...props}
+    />
+  );
 }
-
-ImageHeader.propTypes = {
-  imageUrl: string.isRequired,
-  height: number.isRequired
-};
 
 export { ImageHeader };

--- a/lib/Modal/withModalTrigger.tsx
+++ b/lib/Modal/withModalTrigger.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import Button from "../Button";
 
 export function withModalTrigger(buttonProps: any) {
@@ -10,10 +9,6 @@ export function withModalTrigger(buttonProps: any) {
       this.showModal = this.showModal.bind(this);
       this.onHide = this.onHide.bind(this);
     }
-
-    static propTypes = {
-      children: PropTypes.node.isRequired,
-    };
 
     onHide() {
       this.setState({ show: false });

--- a/lib/Navigation/index.tsx
+++ b/lib/Navigation/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 
 export function Navigation(props: any) {
@@ -34,17 +33,6 @@ export function Navigation(props: any) {
 Navigation.defaultProps = {
   tabs: false,
   className: "",
-};
-
-Navigation.propTypes = {
-  tabs: PropTypes.bool,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]).isRequired,
-  className: PropTypes.string,
 };
 
 export default Navigation;

--- a/lib/Notification/bar/NotificationBarBase.tsx
+++ b/lib/Notification/bar/NotificationBarBase.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import cx from 'classnames';
-import Button from '../../Button';
-import Icon from '../../Icon';
-import { defaults, types } from './barTypes';
+import React from "react";
+import cx from "classnames";
+import Button from "../../Button";
+import Icon from "../../Icon";
+import { defaults } from "./barTypes";
 
 /**
  * @usage
@@ -18,10 +18,10 @@ function NotificationBarBase({
   ...rest
 }: any) {
   const classes = cx({
-    'cursor-pointer': clickHandler,
-    'text-center': center,
+    "cursor-pointer": clickHandler,
+    "text-center": center,
     flex: onClose,
-    'justify-end': center && onClose
+    "justify-end": center && onClose,
   });
 
   return (
@@ -37,7 +37,7 @@ function NotificationBarBase({
       {onClose && (
         <Button
           onClick={onClose}
-          types={['icon-only']}
+          types={["icon-only"]}
           className="notification__close ml-auto"
         >
           <Icon
@@ -52,7 +52,5 @@ function NotificationBarBase({
 }
 
 NotificationBarBase.defaultProps = defaults;
-
-NotificationBarBase.propTypes = types;
 
 export default NotificationBarBase;

--- a/lib/Notification/bar/NotificationBarDanger.tsx
+++ b/lib/Notification/bar/NotificationBarDanger.tsx
@@ -1,22 +1,18 @@
 import React from "react";
-import { defaults, types } from "./barTypes";
+import { defaults } from "./barTypes";
 import NotificationBarBase from "./NotificationBarBase";
 
-export function NotificationBarDanger({
-  children,
-  className,
-  ...rest
-}: any) {
-  return <NotificationBarBase
-    {...rest}
-    className={`bg-red-primary text-white ${className}`}
-  >
-    {children}
-  </NotificationBarBase>
+export function NotificationBarDanger({ children, className, ...rest }: any) {
+  return (
+    <NotificationBarBase
+      {...rest}
+      className={`bg-red-primary text-white ${className}`}
+    >
+      {children}
+    </NotificationBarBase>
+  );
 }
 
 NotificationBarDanger.defaultProps = defaults;
-
-NotificationBarDanger.propTypes = types;
 
 export default NotificationBarDanger;

--- a/lib/Notification/bar/NotificationBarInformation.tsx
+++ b/lib/Notification/bar/NotificationBarInformation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults, types } from "./barTypes";
+import { defaults } from "./barTypes";
 import NotificationBarBase from "./NotificationBarBase";
 
 export function NotificationBarInformation({
@@ -7,16 +7,16 @@ export function NotificationBarInformation({
   className,
   ...rest
 }: any) {
-  return <NotificationBarBase
-    {...rest}
-    className={`bg-blue-primary text-white ${className}`}
-  >
-    {children}
-  </NotificationBarBase>
+  return (
+    <NotificationBarBase
+      {...rest}
+      className={`bg-blue-primary text-white ${className}`}
+    >
+      {children}
+    </NotificationBarBase>
+  );
 }
 
 NotificationBarInformation.defaultProps = defaults;
-
-NotificationBarInformation.propTypes = types;
 
 export default NotificationBarInformation;

--- a/lib/Notification/bar/NotificationBarPromo.tsx
+++ b/lib/Notification/bar/NotificationBarPromo.tsx
@@ -1,18 +1,18 @@
 import React from "react";
-import { defaults, types } from "./barTypes";
+import { defaults } from "./barTypes";
 import NotificationBarBase from "./NotificationBarBase";
 
 export function NotificationBarPromo({ children, className, ...rest }: any) {
-  return <NotificationBarBase
-    {...rest}
-    className={`bg-purple-primary text-white ${className}`}
-  >
-    {children}
-  </NotificationBarBase>
+  return (
+    <NotificationBarBase
+      {...rest}
+      className={`bg-purple-primary text-white ${className}`}
+    >
+      {children}
+    </NotificationBarBase>
+  );
 }
 
 NotificationBarPromo.defaultProps = defaults;
-
-NotificationBarPromo.propTypes = types;
 
 export default NotificationBarPromo;

--- a/lib/Notification/bar/NotificationBarWarning.tsx
+++ b/lib/Notification/bar/NotificationBarWarning.tsx
@@ -1,22 +1,18 @@
 import React from "react";
-import { defaults, types } from "./barTypes";
+import { defaults } from "./barTypes";
 import NotificationBarBase from "./NotificationBarBase";
 
-export function NotificationBarWarning({
-  children,
-  className,
-  ...rest
-}: any) {
-  return <NotificationBarBase
-    {...rest}
-    className={`bg-yellow-primary text-neutral-20 ${className}`}
-  >
-    {children}
-  </NotificationBarBase>
+export function NotificationBarWarning({ children, className, ...rest }: any) {
+  return (
+    <NotificationBarBase
+      {...rest}
+      className={`bg-yellow-primary text-neutral-20 ${className}`}
+    >
+      {children}
+    </NotificationBarBase>
+  );
 }
 
 NotificationBarWarning.defaultProps = defaults;
-
-NotificationBarWarning.propTypes = types;
 
 export default NotificationBarWarning;

--- a/lib/Notification/bar/index.tsx
+++ b/lib/Notification/bar/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { string } from "prop-types";
-import { defaults, types } from "./barTypes";
+import { defaults } from "./barTypes";
 import NotificationBarDanger from "./NotificationBarDanger";
 import NotificationBarInformation from "./NotificationBarInformation";
 import NotificationBarPromo from "./NotificationBarPromo";
@@ -30,11 +29,6 @@ export function NotificationBar({ level, children, ...rest }: any) {
 NotificationBar.defaultProps = {
   ...defaults,
   level: "warning",
-};
-
-NotificationBar.propTypes = {
-  ...types,
-  level: string,
 };
 
 export default NotificationBar;

--- a/lib/Notification/inline/NotificationInlineBase.tsx
+++ b/lib/Notification/inline/NotificationInlineBase.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { string } from 'prop-types';
-import cx from 'classnames';
-import { defaults, types } from './inlineTypes';
-import Icon from '../../Icon';
+import React from "react";
+import cx from "classnames";
+import { defaults } from "./inlineTypes";
+import Icon from "../../Icon";
 
 /**
  * @usage
@@ -11,14 +10,14 @@ import Icon from '../../Icon';
  */
 function NotificationInlineBase({
   children,
-  className = '',
-  textClassName = '',
+  className = "",
+  textClassName = "",
   iconName,
   showShadow,
   ...rest
 }: any) {
   const classes = cx({
-    'shadow-large': showShadow
+    "shadow-large": showShadow,
   });
   return (
     <div
@@ -37,10 +36,5 @@ function NotificationInlineBase({
 }
 
 NotificationInlineBase.defaultProps = defaults;
-
-NotificationInlineBase.propTypes = {
-  ...types,
-  iconName: string.isRequired
-};
 
 export default NotificationInlineBase;

--- a/lib/Notification/inline/NotificationInlineDanger.tsx
+++ b/lib/Notification/inline/NotificationInlineDanger.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults, types } from "./inlineTypes";
+import { defaults } from "./inlineTypes";
 import NotificationInlineBase from "./NotificationInlineBase";
 
 export function NotificationInlineDanger({
@@ -7,17 +7,18 @@ export function NotificationInlineDanger({
   className = "",
   ...rest
 }: any) {
-  return <NotificationInlineBase
-    iconName="warningOctogon"
-    className={`border-red-primary ${className}`}
-    textClassName="text-red-primary"
-    {...rest}
-  >
-    {children}
-  </NotificationInlineBase>
+  return (
+    <NotificationInlineBase
+      iconName="warningOctogon"
+      className={`border-red-primary ${className}`}
+      textClassName="text-red-primary"
+      {...rest}
+    >
+      {children}
+    </NotificationInlineBase>
+  );
 }
 
 NotificationInlineDanger.defaultProps = defaults;
-NotificationInlineDanger.propTypes = types;
 
 export default NotificationInlineDanger;

--- a/lib/Notification/inline/NotificationInlineInformation.tsx
+++ b/lib/Notification/inline/NotificationInlineInformation.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults, types } from "./inlineTypes";
+import { defaults } from "./inlineTypes";
 import NotificationInlineBase from "./NotificationInlineBase";
 
 export function NotificationInlineInformation({
@@ -7,17 +7,18 @@ export function NotificationInlineInformation({
   className = "",
   ...rest
 }: any) {
-  return <NotificationInlineBase
-    iconName="infoSquare"
-    className={`border-blue-primary ${className}`}
-    textClassName="text-blue-primary"
-    {...rest}
-  >
-    {children}
-  </NotificationInlineBase>
+  return (
+    <NotificationInlineBase
+      iconName="infoSquare"
+      className={`border-blue-primary ${className}`}
+      textClassName="text-blue-primary"
+      {...rest}
+    >
+      {children}
+    </NotificationInlineBase>
+  );
 }
 
 NotificationInlineInformation.defaultProps = defaults;
-NotificationInlineInformation.propTypes = types;
 
 export default NotificationInlineInformation;

--- a/lib/Notification/inline/NotificationInlineSuccess.tsx
+++ b/lib/Notification/inline/NotificationInlineSuccess.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults, types } from "./inlineTypes";
+import { defaults } from "./inlineTypes";
 import NotificationInlineBase from "./NotificationInlineBase";
 
 export function NotificationInlineSuccess({
@@ -7,17 +7,18 @@ export function NotificationInlineSuccess({
   className = "",
   ...rest
 }: any) {
-  return <NotificationInlineBase
-    iconName="approved"
-    className={`border-green-primary ${className}`}
-    textClassName="text-green-primary"
-    {...rest}
-  >
-    {children}
-  </NotificationInlineBase>
+  return (
+    <NotificationInlineBase
+      iconName="approved"
+      className={`border-green-primary ${className}`}
+      textClassName="text-green-primary"
+      {...rest}
+    >
+      {children}
+    </NotificationInlineBase>
+  );
 }
 
 NotificationInlineSuccess.defaultProps = defaults;
-NotificationInlineSuccess.propTypes = types;
 
 export default NotificationInlineSuccess;

--- a/lib/Notification/inline/NotificationInlineWarning.tsx
+++ b/lib/Notification/inline/NotificationInlineWarning.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { defaults, types } from "./inlineTypes";
+import { defaults } from "./inlineTypes";
 import NotificationInlineBase from "./NotificationInlineBase";
 
 export function NotificationInlineWarning({
@@ -7,17 +7,18 @@ export function NotificationInlineWarning({
   className = "",
   ...rest
 }: any) {
-  return <NotificationInlineBase
-    iconName="warningTriangle"
-    className={`border-yellow-primary ${className}`}
-    textClassName="text-yellow-primary"
-    {...rest}
-  >
-    {children}
-  </NotificationInlineBase>
+  return (
+    <NotificationInlineBase
+      iconName="warningTriangle"
+      className={`border-yellow-primary ${className}`}
+      textClassName="text-yellow-primary"
+      {...rest}
+    >
+      {children}
+    </NotificationInlineBase>
+  );
 }
 
 NotificationInlineWarning.defaultProps = defaults;
-NotificationInlineWarning.propTypes = types;
 
 export default NotificationInlineWarning;

--- a/lib/Notification/inline/index.tsx
+++ b/lib/Notification/inline/index.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { string } from "prop-types";
-import { defaults, types } from "./inlineTypes";
+import { defaults } from "./inlineTypes";
 import NotificationInlineDanger from "./NotificationInlineDanger";
 import NotificationInlineInformation from "./NotificationInlineInformation";
 import NotificationInlineSuccess from "./NotificationInlineSuccess";
@@ -30,11 +29,6 @@ export function NotificationInline({ level, children, ...rest }: any) {
 NotificationInline.defaultProps = {
   ...defaults,
   level: "information",
-};
-
-NotificationInline.propTypes = {
-  ...types,
-  level: string,
 };
 
 export default NotificationInline;

--- a/lib/OptionMenu/MenuItem.tsx
+++ b/lib/OptionMenu/MenuItem.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-import { string, func, bool } from 'prop-types';
-import cx from 'classnames';
-import Icon from '../Icon';
+import React from "react";
+import cx from "classnames";
+import Icon from "../Icon";
 
 function MenuItem({
   text,
@@ -13,15 +12,15 @@ function MenuItem({
 }: any) {
   const classes = cx(
     className,
-    'bg-white hover:bg-neutral-95',
-    'rounded-small w-48 border-0',
-    'py-1 px-2',
-    'mb-1',
-    'flex items-center',
-    'focus:outline-none focus:shadow-blue-focus-sm',
+    "bg-white hover:bg-neutral-95",
+    "rounded-small w-48 border-0",
+    "py-1 px-2",
+    "mb-1",
+    "flex items-center",
+    "focus:outline-none focus:shadow-blue-focus-sm",
     {
-      'text-neutral-20': !selected,
-      'text-blue-primary': selected
+      "text-neutral-20": !selected,
+      "text-blue-primary": selected,
     }
   );
 
@@ -32,7 +31,7 @@ function MenuItem({
           className="pr-2"
           name={iconName}
           defaultActiveColor={false}
-          types={selected ? ['primary-blue'] : []}
+          types={selected ? ["primary-blue"] : []}
           title={iconTitle}
         />
       )}
@@ -41,20 +40,11 @@ function MenuItem({
   );
 }
 
-MenuItem.propTypes = {
-  text: string.isRequired,
-  onClick: func.isRequired,
-  iconName: string,
-  iconTitle: string,
-  selected: bool,
-  className: string
-};
-
 MenuItem.defaultProps = {
   iconName: null,
-  iconTitle: '',
+  iconTitle: "",
   selected: false,
-  className: ''
+  className: "",
 };
 
 export { MenuItem };

--- a/lib/OptionMenu/OptionMenu.tsx
+++ b/lib/OptionMenu/OptionMenu.tsx
@@ -1,12 +1,7 @@
-import React from 'react';
-import { node, string } from 'prop-types';
-import { MenuItem } from './MenuItem';
+import React from "react";
+import { MenuItem } from "./MenuItem";
 
-function OptionMenu({
-  children,
-  className,
-  ...rest
-}: any) {
+function OptionMenu({ children, className, ...rest }: any) {
   return (
     <div className={`${className} px-4 py-2`} {...rest}>
       {children}
@@ -14,13 +9,8 @@ function OptionMenu({
   );
 }
 
-OptionMenu.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 OptionMenu.defaultProps = {
-  className: ''
+  className: "",
 };
 
 OptionMenu.MenuItem = MenuItem;

--- a/lib/PageInformation/index.tsx
+++ b/lib/PageInformation/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { EditableTextWrapper } from "lib";
 
 export function PageInformation({
@@ -10,37 +9,30 @@ export function PageInformation({
   contextName,
   inputLabel,
 }: any) {
-  return <div className="page-information">
-    {editable ? (
-      <EditableTextWrapper
-        value={title}
-        onChange={rename}
-        title={`Rename ${contextName}`}
-        className="page-information__editable"
-        inputLabel={inputLabel || `Rename ${contextName}`}
-      >
+  return (
+    <div className="page-information">
+      {editable ? (
+        <EditableTextWrapper
+          value={title}
+          onChange={rename}
+          title={`Rename ${contextName}`}
+          className="page-information__editable"
+          inputLabel={inputLabel || `Rename ${contextName}`}
+        >
+          <h1 className="page-information__title" title={title}>
+            {title}
+          </h1>
+        </EditableTextWrapper>
+      ) : (
         <h1 className="page-information__title" title={title}>
           {title}
         </h1>
-      </EditableTextWrapper>
-    ) : (
-      <h1 className="page-information__title" title={title}>
-        {title}
-      </h1>
-    )}
+      )}
 
-    {subtitle && <div className="page-information__subtitle">{subtitle}</div>}
-  </div>
+      {subtitle && <div className="page-information__subtitle">{subtitle}</div>}
+    </div>
+  );
 }
-
-PageInformation.propTypes = {
-  title: PropTypes.string.isRequired,
-  subtitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  editable: PropTypes.bool,
-  rename: PropTypes.func,
-  contextName: PropTypes.string,
-  inputLabel: PropTypes.string,
-};
 
 PageInformation.defaultProps = {
   subtitle: "",

--- a/lib/ParticipantInfo/index.tsx
+++ b/lib/ParticipantInfo/index.tsx
@@ -1,16 +1,12 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function ParticipantInfo({ name, email }: any) {
-  return <div className="participant_info">
-    <p className="participant_info__name">{name}</p>
-    <p className="participant_info__email">{email}</p>
-  </div>
+  return (
+    <div className="participant_info">
+      <p className="participant_info__name">{name}</p>
+      <p className="participant_info__email">{email}</p>
+    </div>
+  );
 }
-
-ParticipantInfo.propTypes = {
-  name: PropTypes.string.isRequired,
-  email: PropTypes.string.isRequired,
-};
 
 export default ParticipantInfo;

--- a/lib/Pill/PillBase.tsx
+++ b/lib/Pill/PillBase.tsx
@@ -1,17 +1,12 @@
-import React from 'react';
-import cx from 'classnames';
-import { propTypes, defaultProps, sizes } from './common';
+import React from "react";
+import cx from "classnames";
+import { defaultProps, sizes } from "./common";
 
-function PillBase({
-  className,
-  children,
-  size,
-  ...rest
-}: any) {
+function PillBase({ className, children, size, ...rest }: any) {
   const classes = cx(`pill inline-flex items-center rounded ${className}`, {
-    'py-1 px-3 text-base': size === sizes.md,
-    'p-1 px-05 text-xs font-semi-bold leading-4': size === sizes.xs,
-    'text-[0.625rem] h-4 px-1': size === sizes.xxs
+    "py-1 px-3 text-base": size === sizes.md,
+    "p-1 px-05 text-xs font-semi-bold leading-4": size === sizes.xs,
+    "text-[0.625rem] h-4 px-1": size === sizes.xxs,
   });
 
   return (
@@ -20,8 +15,6 @@ function PillBase({
     </span>
   );
 }
-
-PillBase.propTypes = propTypes;
 
 PillBase.defaultProps = defaultProps;
 

--- a/lib/Pill/PillBeta.tsx
+++ b/lib/Pill/PillBeta.tsx
@@ -1,12 +1,8 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-export function PillBeta({
-  className,
-  children,
-  ...rest
-}: any) {
+export function PillBeta({ className, children, ...rest }: any) {
   return (
     <PillBase
       className={`bg-purple-60 text-white font-semi-bold inherit-color-icon ${className}`}
@@ -16,7 +12,5 @@ export function PillBeta({
     </PillBase>
   );
 }
-
-PillBeta.propTypes = propTypes;
 
 PillBeta.defaultProps = defaultProps;

--- a/lib/Pill/PillBlueWhiteText.tsx
+++ b/lib/Pill/PillBlueWhiteText.tsx
@@ -1,21 +1,17 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-function PillBlueWhiteText({
-  className,
-  children,
-  ...rest
-}: any) {
-  return <PillBase
-    className={`bg-blue-primary text-white font-semi-bold inherit-color-icon ${className}`}
-    {...rest}
-  >
-    {children}
-  </PillBase>
+function PillBlueWhiteText({ className, children, ...rest }: any) {
+  return (
+    <PillBase
+      className={`bg-blue-primary text-white font-semi-bold inherit-color-icon ${className}`}
+      {...rest}
+    >
+      {children}
+    </PillBase>
+  );
 }
-
-PillBlueWhiteText.propTypes = propTypes;
 
 PillBlueWhiteText.defaultProps = defaultProps;
 

--- a/lib/Pill/PillDefault.tsx
+++ b/lib/Pill/PillDefault.tsx
@@ -1,16 +1,11 @@
-import React from 'react';
-import cx from 'classnames';
-import { propTypes, defaultProps, sizes } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import cx from "classnames";
+import { defaultProps, sizes } from "./common";
+import PillBase from "./PillBase";
 
-function PillDefault({
-  className,
-  children,
-  size,
-  ...rest
-}: any) {
+function PillDefault({ className, children, size, ...rest }: any) {
   const classes = cx(`bg-neutral-90 border-neutral-90 ${className}`, {
-    'text-neutral-primary': size === sizes.xs
+    "text-neutral-primary": size === sizes.xs,
   });
 
   return (
@@ -19,8 +14,6 @@ function PillDefault({
     </PillBase>
   );
 }
-
-PillDefault.propTypes = propTypes;
 
 PillDefault.defaultProps = defaultProps;
 

--- a/lib/Pill/PillGreen.tsx
+++ b/lib/Pill/PillGreen.tsx
@@ -1,21 +1,17 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-function PillGreen({
-  className,
-  children,
-  ...rest
-}: any) {
-  return <PillBase
-    className={`bg-green-90 text-green-primary font-semi-bold inherit-color-icon ${className}`}
-    {...rest}
-  >
-    {children}
-  </PillBase>
+function PillGreen({ className, children, ...rest }: any) {
+  return (
+    <PillBase
+      className={`bg-green-90 text-green-primary font-semi-bold inherit-color-icon ${className}`}
+      {...rest}
+    >
+      {children}
+    </PillBase>
+  );
 }
-
-PillGreen.propTypes = propTypes;
 
 PillGreen.defaultProps = defaultProps;
 

--- a/lib/Pill/PillGreenWhiteText.tsx
+++ b/lib/Pill/PillGreenWhiteText.tsx
@@ -1,21 +1,17 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-function PillGreenWhiteText({
-  className,
-  children,
-  ...rest
-}: any) {
-  return <PillBase
-    className={`bg-green-primary text-white font-semi-bold inherit-color-icon ${className}`}
-    {...rest}
-  >
-    {children}
-  </PillBase>
+function PillGreenWhiteText({ className, children, ...rest }: any) {
+  return (
+    <PillBase
+      className={`bg-green-primary text-white font-semi-bold inherit-color-icon ${className}`}
+      {...rest}
+    >
+      {children}
+    </PillBase>
+  );
 }
-
-PillGreenWhiteText.propTypes = propTypes;
 
 PillGreenWhiteText.defaultProps = defaultProps;
 

--- a/lib/Pill/PillPurple.tsx
+++ b/lib/Pill/PillPurple.tsx
@@ -1,21 +1,17 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-function PillPurple({
-  className,
-  children,
-  ...rest
-}: any) {
-  return <PillBase
-    className={`bg-purple-90 text-purple-primary font-semi-bold inherit-color-icon ${className}`}
-    {...rest}
-  >
-    {children}
-  </PillBase>
+function PillPurple({ className, children, ...rest }: any) {
+  return (
+    <PillBase
+      className={`bg-purple-90 text-purple-primary font-semi-bold inherit-color-icon ${className}`}
+      {...rest}
+    >
+      {children}
+    </PillBase>
+  );
 }
-
-PillPurple.propTypes = propTypes;
 
 PillPurple.defaultProps = defaultProps;
 

--- a/lib/Pill/PillRed.tsx
+++ b/lib/Pill/PillRed.tsx
@@ -1,21 +1,18 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-function PillRed({
-  className,
-  children,
-  ...rest
-}: any) {
-  return <PillBase
-    className={`bg-red-95 border-2 border-solid border-red-primary text-red-primary inherit-color-icon ${className}`}
-    {...rest}
-  >
-    {children}
-  </PillBase>
+function PillRed({ className, children, ...rest }: any) {
+  return (
+    <PillBase
+      className={`bg-red-95 border-2 border-solid border-red-primary text-red-primary inherit-color-icon ${className}`}
+      {...rest}
+    >
+      {children}
+    </PillBase>
+  );
 }
 
-PillRed.propTypes = propTypes;
 PillRed.defaultProps = defaultProps;
 
 export default PillRed;

--- a/lib/Pill/PillYellow.tsx
+++ b/lib/Pill/PillYellow.tsx
@@ -1,21 +1,17 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
-import PillBase from './PillBase';
+import React from "react";
+import { defaultProps } from "./common";
+import PillBase from "./PillBase";
 
-function PillYellow({
-  className,
-  children,
-  ...rest
-}: any) {
-  return <PillBase
-    className={`bg-yellow-primary text-neutral-20 font-semi-bold inherit-color-icon ${className}`}
-    {...rest}
-  >
-    {children}
-  </PillBase>
+function PillYellow({ className, children, ...rest }: any) {
+  return (
+    <PillBase
+      className={`bg-yellow-primary text-neutral-20 font-semi-bold inherit-color-icon ${className}`}
+      {...rest}
+    >
+      {children}
+    </PillBase>
+  );
 }
-
-PillYellow.propTypes = propTypes;
 
 PillYellow.defaultProps = defaultProps;
 

--- a/lib/Pill/common.ts
+++ b/lib/Pill/common.ts
@@ -1,4 +1,3 @@
-import { node, oneOf, string } from 'prop-types';
 
 export const sizes = {
   md: 'md',
@@ -6,11 +5,7 @@ export const sizes = {
   xxs: 'xxs'
 };
 
-export const propTypes = {
-  children: node.isRequired,
-  className: string,
-  size: oneOf(Object.keys(sizes))
-};
+
 
 export const defaultProps = {
   className: '',

--- a/lib/Pill/index.tsx
+++ b/lib/Pill/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { oneOf } from "prop-types";
-import { propTypes, defaultProps, types, sizes } from "./common";
+import { defaultProps, types, sizes } from "./common";
 import PillDefault from "./PillDefault";
 import PillRed from "./PillRed";
 import PillGreen from "./PillGreen";
@@ -35,11 +35,6 @@ export function Pill({ type, children, ...rest }: any) {
 
   return <PillType {...rest}>{children}</PillType>;
 }
-
-Pill.propTypes = {
-  ...propTypes,
-  type: oneOf(Object.keys(types)),
-};
 
 Pill.defaultProps = {
   ...defaultProps,

--- a/lib/PillInput/DeleteablePill.tsx
+++ b/lib/PillInput/DeleteablePill.tsx
@@ -1,22 +1,16 @@
-import React from 'react';
-import { string, func } from 'prop-types';
-import Pill from '../Pill';
-import Icon from '../Icon';
-import Button from '../Button';
-import TooltipWrapper from '../TooltipWrapper';
+import React from "react";
+import Pill from "../Pill";
+import Icon from "../Icon";
+import Button from "../Button";
+import TooltipWrapper from "../TooltipWrapper";
 
-function DeleteablePill({
-  name,
-  onRemove,
-  warning,
-  id
-}: any) {
+function DeleteablePill({ name, onRemove, warning, id }: any) {
   const pillType = warning ? Pill.types.red : Pill.types.default;
   return (
     <TooltipWrapper id={`pill-input-pill-tooltip-${id}`} tooltipText={warning}>
       <Pill className="mr-1 mb-1" type={pillType}>
         <p className="h-margin-clear h-margin-right-half">{name}</p>
-        <Button onClick={onRemove} types={['clear']}>
+        <Button onClick={onRemove} types={["clear"]}>
           <Icon name="cross" />
         </Button>
       </Pill>
@@ -24,16 +18,9 @@ function DeleteablePill({
   );
 }
 
-DeleteablePill.propTypes = {
-  name: string.isRequired,
-  id: string.isRequired,
-  onRemove: func,
-  warning: string
-};
-
 DeleteablePill.defaultProps = {
   onRemove: () => {},
-  warning: null
+  warning: null,
 };
 
 export { DeleteablePill };

--- a/lib/PillInput/PillInput/PillInput.tsx
+++ b/lib/PillInput/PillInput/PillInput.tsx
@@ -1,10 +1,9 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from "react";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'uuid... Remove this comment to see the full error message
-import uuid from 'uuid/v1';
-import { string, arrayOf, bool, instanceOf, shape, func } from 'prop-types';
-import cx from 'classnames';
-import { DeleteablePill } from '../DeleteablePill';
-import { useKeyDownHandlers } from './useKeyDownHandlers';
+import uuid from "uuid/v1";
+import cx from "classnames";
+import { DeleteablePill } from "../DeleteablePill";
+import { useKeyDownHandlers } from "./useKeyDownHandlers";
 
 function PillInput({
   className,
@@ -17,12 +16,12 @@ function PillInput({
   const checkPill = (pillName: any) => !checker || checker.regex.test(pillName);
   const initialPillsValidated = initialPills.map((pill: any) => ({
     ...pill,
-    isValid: checkPill(pill.name)
+    isValid: checkPill(pill.name),
   }));
 
   const [isFocused, setIsFocused] = useState(false);
   const [pills, setPills] = useState(initialPillsValidated);
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState("");
 
   const addPills = (pillNames: any) => {
     const pillsToAdd = pillNames.reduce((acc: any, pillName: any) => {
@@ -48,7 +47,7 @@ function PillInput({
   };
 
   const onChange = (value: any) => {
-    const pillNamesFromValue = value.split(' ');
+    const pillNamesFromValue = value.split(" ");
     const numberOfPillNames = pillNamesFromValue.length;
 
     if (numberOfPillNames === 1) {
@@ -70,14 +69,14 @@ function PillInput({
 
   const onBlur = () => {
     addPills([inputValue]);
-    setInputValue('');
+    setInputValue("");
     setIsFocused(false);
   };
 
   const containerClassName = cx(
     `${className} pill-input__container form__input h-padding-quarter h-padding-bottom-clear`,
     {
-      'pill-input--focused': isFocused
+      "pill-input--focused": isFocused,
     }
   );
 
@@ -93,28 +92,24 @@ function PillInput({
     removeLastPill,
     inputValue,
     setInputValue,
-    inputRef
+    inputRef,
   });
 
   return (
     <div className={containerClassName}>
-      {pills.map(({
-        id,
-        name,
-        isValid
-      }: any) => (
-          <DeleteablePill
-            key={id}
-            id={id}
-            name={name}
-            onRemove={() => removePill(id)}
-            warning={isValid ? null : checker.warning}
-          />
-        ))}
+      {pills.map(({ id, name, isValid }: any) => (
+        <DeleteablePill
+          key={id}
+          id={id}
+          name={name}
+          onRemove={() => removePill(id)}
+          warning={isValid ? null : checker.warning}
+        />
+      ))}
       <input
         {...rest}
         ref={inputRef}
-        placeholder={!pills.length ? placeholder : ''}
+        placeholder={!pills.length ? placeholder : ""}
         className="pill-input__input h-margin-bottom-quarter h-margin-right-quarter h-padding-bottom-quarter h-padding-top-quarter h-padding-left-quarter h-padding-right-quarter"
         value={inputValue}
         onChange={({ target: { value } }) => onChange(value)}
@@ -125,29 +120,12 @@ function PillInput({
   );
 }
 
-PillInput.propTypes = {
-  className: string,
-  placeholder: string,
-  checker: shape({
-    warning: string,
-    regex: instanceOf(RegExp)
-  }),
-  onPillsChange: func,
-  initialPills: arrayOf(
-    shape({ name: string.isRequired, id: string.isRequired })
-  )
-};
-
 PillInput.defaultProps = {
-  className: '',
+  className: "",
   checker: null,
-  placeholder: '',
+  placeholder: "",
   onPillsChange: () => {},
-  initialPills: []
-};
-
-PillInput.exportedPropTypes = {
-  pill: shape({ name: string, isValid: bool })
+  initialPills: [],
 };
 
 export { PillInput };

--- a/lib/PillInput/stories/PillInput.stories.tsx
+++ b/lib/PillInput/stories/PillInput.stories.tsx
@@ -1,43 +1,46 @@
-import React from 'react';
-import { PillInput as PillInputComponent } from '../PillInput/PillInput';
-import StoryItem from '../../../stories/styleguide/StoryItem';
+import React from "react";
+import { PillInput as PillInputComponent } from "../PillInput/PillInput";
+import StoryItem from "../../../stories/styleguide/StoryItem";
 
 export default {
-  title: 'Legacy/Form/Inputs/Pill Input',
-  component: PillInputComponent
+  title: "Legacy/Form/Inputs/Pill Input",
+  component: PillInputComponent,
 };
 
-const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+const emailRegex =
+  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
 export function PillInput() {
-  return <div>
-    <StoryItem
-      title="PillInputComponent"
-      description="Text input that creates pills"
-    >
-      <PillInputComponent
-        placeholder="Enter an email"
-        checker={{
-          warning: 'This is not a valid email address!',
-          regex: emailRegex
-        }}
-        // eslint-disable-next-line no-console
-        onPillsChange={pills => console.log(pills)}
-        initialPills={[
-          {
-            id: 'b414a7bc-ddb5-4a2d-92a3-332a1f89ebcc',
-            name: 'valid@example.com'
-          },
-          {
-            id: 'cfb0b362-1c34-4b9b-b489-93a68df6045d',
-            name: 'invalid@example'
-          }
-        ]}
-      />
-    </StoryItem>
-  </div>
+  return (
+    <div>
+      <StoryItem
+        title="PillInputComponent"
+        description="Text input that creates pills"
+      >
+        <PillInputComponent
+          placeholder="Enter an email"
+          checker={{
+            warning: "This is not a valid email address!",
+            regex: emailRegex,
+          }}
+          // eslint-disable-next-line no-console
+          onPillsChange={(pills: any) => console.log(pills)}
+          initialPills={[
+            {
+              id: "b414a7bc-ddb5-4a2d-92a3-332a1f89ebcc",
+              name: "valid@example.com",
+            },
+            {
+              id: "cfb0b362-1c34-4b9b-b489-93a68df6045d",
+              name: "invalid@example",
+            },
+          ]}
+        />
+      </StoryItem>
+    </div>
+  );
 }
 
 PillInput.parameters = {
-  controls: { hideNoControlsWarning: true }
+  controls: { hideNoControlsWarning: true },
 };

--- a/lib/Progress/Bar/index.tsx
+++ b/lib/Progress/Bar/index.tsx
@@ -1,23 +1,14 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-function ProgressBar({
-  className,
-  children
-}: any) {
-  const classes = cx(['progress__bar', className]);
+function ProgressBar({ className, children }: any) {
+  const classes = cx(["progress__bar", className]);
 
   return <div className={classes}>{children}</div>;
 }
 
-ProgressBar.propTypes = {
-  children: PropTypes.node.isRequired,
-  className: PropTypes.string
-};
-
 ProgressBar.defaultProps = {
-  className: ''
+  className: "",
 };
 
 export default ProgressBar;

--- a/lib/ProgressButton/index.tsx
+++ b/lib/ProgressButton/index.tsx
@@ -1,59 +1,43 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React, { Component, useState } from "react";
 import cx from "classnames";
 import Button from "../Button";
 import Icon from "../Icon";
 
-export class ProgressButton extends Component {
-  constructor(props: any) {
-    super(props);
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  buttonType?: string;
+  isSubmit?: boolean;
+  clickHandler: (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  callbackCanExecute?: boolean;
+  showSpinner?: boolean;
+  useShowSpinnerProp?: boolean;
+  autoSpinner?: boolean;
+  spinnerText?: string;
+  onCallbackResolved?: (arg: any) => void;
+}
 
-    this.state = {
-      showSpinner: false,
-    };
-  }
-
-  static defaultProps = {
-    buttonType: "primary",
-    isSubmit: false,
-    callbackCanExecute: true,
-    showSpinner: false,
-    useShowSpinnerProp: false,
-    disabled: false,
-    autoSpinner: false,
-    spinnerText: null,
-    className: "",
-    onCallbackResolved: null,
-  };
-
-  static propTypes = {
-    buttonType: PropTypes.string,
-    clickHandler: PropTypes.func.isRequired,
-    value: PropTypes.node.isRequired,
-    isSubmit: PropTypes.bool,
-    callbackCanExecute: PropTypes.bool,
-    showSpinner: PropTypes.bool,
-    useShowSpinnerProp: PropTypes.bool,
-    disabled: PropTypes.bool,
-    autoSpinner: PropTypes.bool,
-    spinnerText: PropTypes.string,
-    className: PropTypes.string,
-    onCallbackResolved: PropTypes.func,
-  };
-
-  getSpinningState() {
+export function ProgressButton({
+  buttonType = "primary",
+  isSubmit = false,
+  callbackCanExecute = true,
+  showSpinner = false,
+  useShowSpinnerProp = false,
+  disabled,
+  autoSpinner = false,
+  spinnerText,
+  className,
+  onCallbackResolved,
+  value,
+  clickHandler,
+}: Props) {
+  const [showSpinnerState, setShowSpinnerState] = useState(false);
+  const getSpinningState = () => {
     const classes = cx({
-      // @ts-expect-error TS(2339): Property 'spinnerText' does not exist on type 'Rea... Remove this comment to see the full error message
-      "is-hidden": !this.props.spinnerText,
-      // @ts-expect-error TS(2339): Property 'spinnerText' does not exist on type 'Rea... Remove this comment to see the full error message
-      "progress-button__spinner-text": this.props.spinnerText,
+      "is-hidden": !spinnerText,
+      "progress-button__spinner-text": spinnerText,
     });
     return (
       <span className="progress-button__wrapper">
-        <span className={classes}>
-          {/* @ts-expect-error TS(2339): Property 'spinnerText' does not exist on type 'Rea... Remove this comment to see the full error message */}
-          {this.props.spinnerText || this.props.value}
-        </span>
+        <span className={classes}>{spinnerText || value}</span>
         <Icon
           className="progress-button__icon"
           name="loader"
@@ -62,71 +46,50 @@ export class ProgressButton extends Component {
         />
       </span>
     );
-  }
+  };
 
-  getNormalState() {
-    // @ts-expect-error TS(2339): Property 'value' does not exist on type 'Readonly<... Remove this comment to see the full error message
-    return <span>{this.props.value}</span>;
-  }
+  const getNormalState = () => <span>{value}</span>;
 
-  showSpinner() {
-    this.setState({ showSpinner: true });
-  }
-
-  clickHandler = async (e: any) => {
-    // @ts-expect-error TS(2339): Property 'showSpinner' does not exist on type 'Rea... Remove this comment to see the full error message
-    if (this.state.showSpinner || !this.props.callbackCanExecute) {
+  const handleClick = async (e: any) => {
+    if (showSpinner || !callbackCanExecute) {
       return;
     }
 
-    this.showSpinner();
-    // @ts-expect-error TS(2339): Property 'clickHandler' does not exist on type 'Re... Remove this comment to see the full error message
-    const result = await this.props.clickHandler(e);
-    // @ts-expect-error TS(2339): Property 'autoSpinner' does not exist on type 'Rea... Remove this comment to see the full error message
-    if (this.props.autoSpinner) {
-      this.setState({ showSpinner: false });
+    setShowSpinnerState(true);
+    const result = await clickHandler(e);
+    if (autoSpinner) {
+      setShowSpinnerState(false);
     }
 
-    // @ts-expect-error TS(2339): Property 'onCallbackResolved' does not exist on ty... Remove this comment to see the full error message
-    if (this.props.onCallbackResolved) {
-      // @ts-expect-error TS(2339): Property 'onCallbackResolved' does not exist on ty... Remove this comment to see the full error message
-      this.props.onCallbackResolved(result);
+    if (onCallbackResolved) {
+      onCallbackResolved(result);
     }
   };
 
-  render() {
-    let content = null;
-    // @ts-expect-error TS(2339): Property 'useShowSpinnerProp' does not exist on ty... Remove this comment to see the full error message
-    if (this.props.useShowSpinnerProp) {
-      // @ts-expect-error TS(2339): Property 'showSpinner' does not exist on type 'Rea... Remove this comment to see the full error message
-      if (this.props.showSpinner) {
-        content = this.getSpinningState();
-      } else {
-        content = this.getNormalState();
-      }
-      // @ts-expect-error TS(2339): Property 'showSpinner' does not exist on type 'Rea... Remove this comment to see the full error message
-    } else if (this.state.showSpinner) {
-      content = this.getSpinningState();
+  let content = null;
+  if (useShowSpinnerProp) {
+    if (showSpinner) {
+      content = getSpinningState();
     } else {
-      content = this.getNormalState();
+      content = getNormalState();
     }
-
-    return (
-      <Button
-        // @ts-expect-error TS(2339): Property 'buttonType' does not exist on type 'Read... Remove this comment to see the full error message
-        types={[this.props.buttonType]}
-        clickHandler={this.clickHandler}
-        // @ts-expect-error TS(2339): Property 'isSubmit' does not exist on type 'Readon... Remove this comment to see the full error message
-        isSubmit={this.props.isSubmit}
-        // @ts-expect-error TS(2339): Property 'disabled' does not exist on type 'Readon... Remove this comment to see the full error message
-        disabled={this.props.disabled}
-        // @ts-expect-error TS(2339): Property 'className' does not exist on type 'Reado... Remove this comment to see the full error message
-        className={this.props.className}
-      >
-        {content}
-      </Button>
-    );
+  } else if (showSpinnerState) {
+    content = getSpinningState();
+  } else {
+    content = getNormalState();
   }
+
+  return (
+    <Button
+      types={[buttonType]}
+      clickHandler={handleClick}
+      isSubmit={isSubmit}
+      disabled={disabled}
+      className={className}
+    >
+      {content}
+    </Button>
+  );
 }
 
 export default ProgressButton;

--- a/lib/Search/SearchBoundaryListener.tsx
+++ b/lib/Search/SearchBoundaryListener.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import BoundaryClickWatcher from "../BoundaryClickWatcher";
 import { SearchContext } from "./SearchProvider";
 
@@ -26,12 +25,6 @@ export default function ListenerWithContext(props: any) {
 
 SearchBoundaryListener.defaultProps = {
   className: "",
-};
-
-SearchBoundaryListener.propTypes = {
-  children: PropTypes.node.isRequired,
-  hideBody: PropTypes.func.isRequired,
-  className: PropTypes.string,
 };
 
 export { SearchBoundaryListener as PureSearchBoundaryListener };

--- a/lib/Search/SearchInput.tsx
+++ b/lib/Search/SearchInput.tsx
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import cx from "classnames";
-import PropTypes from "prop-types";
 import Button from "../Button";
 import Icon from "../Icon";
 import ShortcutTrigger from "../ShortcutTrigger";
@@ -103,15 +102,6 @@ class SearchInput extends Component {
 SearchInput.defaultProps = {
   className: "",
   showBody: false,
-};
-
-// @ts-expect-error TS(2339): Property 'propTypes' does not exist on type 'typeo... Remove this comment to see the full error message
-SearchInput.propTypes = {
-  className: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
-  hideBody: PropTypes.func.isRequired,
-  displayBody: PropTypes.func.isRequired,
-  showBody: PropTypes.bool,
 };
 
 export default SearchInput;

--- a/lib/Search/SearchList.tsx
+++ b/lib/Search/SearchList.tsx
@@ -1,22 +1,18 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
 function SearchList(props: any) {
-  return <div className="search-list">
-  {props.heading && (
-    <div className="search-list__heading">{props.heading}</div>
-  )}
-  {props.children}
-</div>
+  return (
+    <div className="search-list">
+      {props.heading && (
+        <div className="search-list__heading">{props.heading}</div>
+      )}
+      {props.children}
+    </div>
+  );
 }
 
 SearchList.defaultProps = {
-  heading: ''
-};
-
-SearchList.propTypes = {
-  children: PropTypes.node.isRequired,
-  heading: PropTypes.string
+  heading: "",
 };
 
 export default SearchList;

--- a/lib/Search/SearchListItem.tsx
+++ b/lib/Search/SearchListItem.tsx
@@ -1,27 +1,22 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
 function SearchListItem(props: any) {
-  return <div className="search-item">
-  {props.title && <div className="search-item__title">{props.title}</div>}
-  {props.children && (
-    <div className="search-item__content">{props.children}</div>
-  )}
-  {props.subText && (
-    <div className="search-item__subtext">{props.subText}</div>
-  )}
-</div>
+  return (
+    <div className="search-item">
+      {props.title && <div className="search-item__title">{props.title}</div>}
+      {props.children && (
+        <div className="search-item__content">{props.children}</div>
+      )}
+      {props.subText && (
+        <div className="search-item__subtext">{props.subText}</div>
+      )}
+    </div>
+  );
 }
 
 SearchListItem.defaultProps = {
-  title: '',
-  subText: ''
-};
-
-SearchListItem.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
-  title: PropTypes.string,
-  subText: PropTypes.string
+  title: "",
+  subText: "",
 };
 
 export default SearchListItem;

--- a/lib/Search/SearchOptions.tsx
+++ b/lib/Search/SearchOptions.tsx
@@ -1,12 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
 function SearchOptions(props: any) {
-  return <div className="search-options">{props.children}</div>
+  return <div className="search-options">{props.children}</div>;
 }
-
-SearchOptions.propTypes = {
-  children: PropTypes.node.isRequired
-};
 
 export default SearchOptions;

--- a/lib/Search/SearchProvider.tsx
+++ b/lib/Search/SearchProvider.tsx
@@ -2,7 +2,11 @@ import React, { useState } from "react";
 
 export const SearchContext = React.createContext({});
 
-export function SearchProvider({ children }: { children: React.ReactNode }) {
+export function SearchProvider({
+  children,
+}: {
+  children: React.ReactNode | JSX.Element;
+}) {
   const [showBody, setShowBody] = useState(false);
   const displayBody = () => setShowBody(true);
 

--- a/lib/Search/ToggleFilter.tsx
+++ b/lib/Search/ToggleFilter.tsx
@@ -1,23 +1,18 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import CheckToggle from '../CheckToggle';
+import React from "react";
+import CheckToggle from "../CheckToggle";
 
 function ToggleFilter(props: any) {
-  return <div className="search-options__toggle">
-  <CheckToggle
-    id="search-toggle"
-    labelRight={props.label}
-    displaySmall
-    displayChecked={props.displayChecked}
-    clickHandler={props.clickHandler}
-  />
-</div>
+  return (
+    <div className="search-options__toggle">
+      <CheckToggle
+        id="search-toggle"
+        labelRight={props.label}
+        displaySmall
+        displayChecked={props.displayChecked}
+        clickHandler={props.clickHandler}
+      />
+    </div>
+  );
 }
-
-ToggleFilter.propTypes = {
-  clickHandler: PropTypes.func.isRequired,
-  label: PropTypes.string.isRequired,
-  displayChecked: PropTypes.bool.isRequired
-};
 
 export default ToggleFilter;

--- a/lib/SearchDropdown/index.tsx
+++ b/lib/SearchDropdown/index.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import Icon from "../Icon";
 import SearchResults from "./SearchResults";
@@ -116,22 +115,6 @@ SearchDropdown.defaultProps = {
   onInputClear: () => {},
   direction: "down",
   focusOnMount: false,
-};
-
-// @ts-expect-error TS(2339): Property 'propTypes' does not exist on type 'typeo... Remove this comment to see the full error message
-SearchDropdown.propTypes = {
-  placeholder: PropTypes.string,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  results: PropTypes.arrayOf(PropTypes.shape()),
-  alignRight: PropTypes.bool,
-  fullWidth: PropTypes.bool,
-  className: PropTypes.string,
-  direction: PropTypes.string,
-  resultsTitle: PropTypes.string,
-  listClassName: PropTypes.string,
-  handleOnChange: PropTypes.func,
-  onInputClear: PropTypes.func,
-  focusOnMount: PropTypes.bool,
 };
 
 export default SearchDropdown;

--- a/lib/SearchInput/index.tsx
+++ b/lib/SearchInput/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { animated, useTransition } from "react-spring";
 import Icon from "../Icon";
 
@@ -61,18 +60,6 @@ SearchInput.defaultProps = {
   id: null,
   className: "",
   inputClassName: "",
-};
-
-SearchInput.propTypes = {
-  placeholder: PropTypes.string,
-  onChangeHandler: PropTypes.func.isRequired,
-  onClearHandler: PropTypes.func.isRequired,
-  hideIcon: PropTypes.bool,
-  value: PropTypes.string,
-  label: PropTypes.string,
-  id: PropTypes.string,
-  className: PropTypes.string,
-  inputClassName: PropTypes.string,
 };
 
 export default SearchInput;

--- a/lib/SectionFeature/SectionFeature.tsx
+++ b/lib/SectionFeature/SectionFeature.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 
 export function SectionFeature({
@@ -15,18 +14,6 @@ export function SectionFeature({
 
   return <div className={classNames}>{children}</div>;
 }
-
-SectionFeature.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.shape(),
-  ]).isRequired,
-  extendTop: PropTypes.bool,
-  enhanceIntro: PropTypes.bool,
-  className: PropTypes.string,
-};
 
 SectionFeature.defaultProps = {
   extendTop: false,

--- a/lib/SelectionBar/SelectionBarAction.tsx
+++ b/lib/SelectionBar/SelectionBarAction.tsx
@@ -1,14 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
 
-function SelectionBarAction({
-  children
-}: any) {
-  return <div className="selection-bar__action">{children}</div>
+function SelectionBarAction({ children }: any) {
+  return <div className="selection-bar__action">{children}</div>;
 }
-
-SelectionBarAction.propTypes = {
-  children: PropTypes.node.isRequired
-};
 
 export default SelectionBarAction;

--- a/lib/SelectionBar/SelectionBarActions.tsx
+++ b/lib/SelectionBar/SelectionBarActions.tsx
@@ -1,20 +1,17 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Col } from "lib";
 
 function SelectionBarActions({ children }: any) {
-  return <Col
-    xs={12}
-    sm={5}
-    md={6}
-    className="selection-bar__section selection-bar__actions"
-  >
-    {children}
-  </Col>
+  return (
+    <Col
+      xs={12}
+      sm={5}
+      md={6}
+      className="selection-bar__section selection-bar__actions"
+    >
+      {children}
+    </Col>
+  );
 }
-
-SelectionBarActions.propTypes = {
-  children: PropTypes.node.isRequired,
-};
 
 export default SelectionBarActions;

--- a/lib/SelectionBar/SelectionBarCancel.tsx
+++ b/lib/SelectionBar/SelectionBarCancel.tsx
@@ -1,24 +1,21 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Col } from "lib";
 import ShortcutTrigger from "../ShortcutTrigger";
 import Button from "../Button";
 
 function SelectionBarCancel({ onCancel }: any) {
-  return <Col sm={3} md={3} className="selection-bar__section selection-bar__cancel">
-    <Button
-      title="Cancel Selection"
-      types={["link-default", "collapse"]}
-      clickHandler={onCancel}
-    >
-      Cancel (Esc)
-    </Button>
-    <ShortcutTrigger shortcutKey="Escape" onShortcutTrigger={onCancel} />
-  </Col>
+  return (
+    <Col sm={3} md={3} className="selection-bar__section selection-bar__cancel">
+      <Button
+        title="Cancel Selection"
+        types={["link-default", "collapse"]}
+        clickHandler={onCancel}
+      >
+        Cancel (Esc)
+      </Button>
+      <ShortcutTrigger shortcutKey="Escape" onShortcutTrigger={onCancel} />
+    </Col>
+  );
 }
-
-SelectionBarCancel.propTypes = {
-  onCancel: PropTypes.func.isRequired,
-};
 
 export default SelectionBarCancel;

--- a/lib/SelectionBar/SelectionBarCounter.tsx
+++ b/lib/SelectionBar/SelectionBarCounter.tsx
@@ -1,23 +1,16 @@
-import React, { Fragment } from 'react';
-import { number, string } from 'prop-types';
+import React, { Fragment } from "react";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'plur... Remove this comment to see the full error message
-import pluralize from 'pluralize';
+import pluralize from "pluralize";
 
-function SelectionBarCounter({
-  count,
-  type
-}: any) {
-  return <>
-    <span className="selection-bar__count">{count}</span>
-    <span className="selection-bar__type">
-      {pluralize(type, count)} selected
-    </span>
-  </>
+function SelectionBarCounter({ count, type }: any) {
+  return (
+    <>
+      <span className="selection-bar__count">{count}</span>
+      <span className="selection-bar__type">
+        {pluralize(type, count)} selected
+      </span>
+    </>
+  );
 }
-
-SelectionBarCounter.propTypes = {
-  count: number.isRequired,
-  type: string.isRequired
-};
 
 export default SelectionBarCounter;

--- a/lib/SelectionBar/SelectionBarInformation.tsx
+++ b/lib/SelectionBar/SelectionBarInformation.tsx
@@ -1,23 +1,17 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Col } from "lib";
 
 function SelectionBarInformation(props: any) {
-  return <Col
-    xs={12}
-    sm={4}
-    md={3}
-    className="selection-bar__section selection-bar__information"
-  >
-    {props.children}
-  </Col>
+  return (
+    <Col
+      xs={12}
+      sm={4}
+      md={3}
+      className="selection-bar__section selection-bar__information"
+    >
+      {props.children}
+    </Col>
+  );
 }
-
-SelectionBarInformation.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]).isRequired,
-};
 
 export default SelectionBarInformation;

--- a/lib/SelectionBar/index.tsx
+++ b/lib/SelectionBar/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import { AnimatedWrapper, Row } from "lib";
 import SelectionBarAction from "./SelectionBarAction";
@@ -40,15 +39,6 @@ SelectionBar.Action = SelectionBarAction;
 SelectionBar.Actions = SelectionBarActions;
 SelectionBar.Divider = SelectionBarDivider;
 SelectionBar.Counter = SelectionBarCounter;
-
-SelectionBar.propTypes = {
-  hasSelected: PropTypes.bool.isRequired,
-  children: PropTypes.node.isRequired,
-  fixed: PropTypes.bool,
-  autoHide: PropTypes.bool,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  animatableProperties: PropTypes.shape(),
-};
 
 SelectionBar.defaultProps = {
   fixed: false,

--- a/lib/SelectionModal/SelectionModal.tsx
+++ b/lib/SelectionModal/SelectionModal.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Modal } from "lib";
-import { propTypes, defaultProps } from "./common";
+import { defaultProps } from "./common";
 import SelectionModalBody from "./SelectionModalBody";
 import SelectionModalColumn from "./SelectionModalColumn";
 import SelectionModalColumnHeader from "./SelectionModalColumnHeader";
@@ -14,8 +14,6 @@ export function SelectionModal({ children, className, ...rest }: any) {
     </Modal.Container>
   );
 }
-
-SelectionModal.propTypes = propTypes;
 
 SelectionModal.defaultProps = defaultProps;
 

--- a/lib/SelectionModal/SelectionModalBody.tsx
+++ b/lib/SelectionModal/SelectionModalBody.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Modal, LoadingOverlay } from "lib";
-import { propTypes, defaultProps } from "./common";
+import { defaultProps } from "./common";
 
 function SelectionModalBody({ children, className, isLoading, ...rest }: any) {
   return (
@@ -14,7 +14,5 @@ function SelectionModalBody({ children, className, isLoading, ...rest }: any) {
 }
 
 export default SelectionModalBody;
-
-SelectionModalBody.propTypes = propTypes;
 
 SelectionModalBody.defaultProps = defaultProps;

--- a/lib/SelectionModal/SelectionModalCategory.tsx
+++ b/lib/SelectionModal/SelectionModalCategory.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
-import { bool, string, number } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
 function SelectionModalCategory({
   isSelected,
@@ -13,14 +12,14 @@ function SelectionModalCategory({
   const buttonClasses = cx(
     `bg-white relative border-solid flex w-full rounded outline-none px-3 py-2 border border-neutral-90 items-center ${className}`,
     {
-      'text-input-border-focus': isSelected,
-      'hover:border-blue-primary': !isSelected
+      "text-input-border-focus": isSelected,
+      "hover:border-blue-primary": !isSelected,
     }
   );
 
-  const nameClasses = cx('m-0 mb-1', {
-    'text-neutral-20': !isSelected,
-    'text-blue-primary': isSelected
+  const nameClasses = cx("m-0 mb-1", {
+    "text-neutral-20": !isSelected,
+    "text-blue-primary": isSelected,
   });
 
   return (
@@ -38,19 +37,11 @@ function SelectionModalCategory({
   );
 }
 
-SelectionModalCategory.propTypes = {
-  isSelected: bool,
-  className: string,
-  name: string.isRequired,
-  subText: string,
-  counter: number
-};
-
 SelectionModalCategory.defaultProps = {
   isSelected: false,
-  className: '',
-  subText: '',
-  counter: 0
+  className: "",
+  subText: "",
+  counter: 0,
 };
 
 export default SelectionModalCategory;

--- a/lib/SelectionModal/SelectionModalColumn.tsx
+++ b/lib/SelectionModal/SelectionModalColumn.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { bool } from 'prop-types';
-import cx from 'classnames';
-import { propTypes, defaultProps } from './common';
+import React from "react";
+import { bool } from "prop-types";
+import cx from "classnames";
+import { defaultProps } from "./common";
 
 function SelectionModalColumn({
   children,
@@ -10,7 +10,7 @@ function SelectionModalColumn({
   ...rest
 }: any) {
   const classes = cx(`flex min-h-0 overflow-y-auto flex-col ${className}`, {
-    'bg-neutral-98': isHighlight
+    "bg-neutral-98": isHighlight,
   });
 
   return (
@@ -20,14 +20,9 @@ function SelectionModalColumn({
   );
 }
 
-SelectionModalColumn.propTypes = {
-  ...propTypes,
-  isHighlight: bool
-};
-
 SelectionModalColumn.defaultProps = {
   ...defaultProps,
-  isHighlight: false
+  isHighlight: false,
 };
 
 export default SelectionModalColumn;

--- a/lib/SelectionModal/SelectionModalColumnHeader.tsx
+++ b/lib/SelectionModal/SelectionModalColumnHeader.tsx
@@ -1,11 +1,7 @@
-import React from 'react';
-import { propTypes, defaultProps } from './common';
+import React from "react";
+import { defaultProps } from "./common";
 
-function SelectionModalColumnHeader({
-  children,
-  className,
-  ...rest
-}: any) {
+function SelectionModalColumnHeader({ children, className, ...rest }: any) {
   return (
     <h4
       className={`text-xs weight-semi-bold text-neutral-primary ${className}`}
@@ -15,8 +11,6 @@ function SelectionModalColumnHeader({
     </h4>
   );
 }
-
-SelectionModalColumnHeader.propTypes = propTypes;
 
 SelectionModalColumnHeader.defaultProps = defaultProps;
 

--- a/lib/SelectionModal/common.ts
+++ b/lib/SelectionModal/common.ts
@@ -1,9 +1,6 @@
 import { node, string } from 'prop-types';
 
-export const propTypes = {
-  children: node.isRequired,
-  className: string
-};
+
 
 export const defaultProps = {
   className: ''

--- a/lib/SelectionProvider/index.tsx
+++ b/lib/SelectionProvider/index.tsx
@@ -1,14 +1,10 @@
-import React, { useState } from 'react';
-import { node, arrayOf, oneOfType, string, number } from 'prop-types';
-import { omit } from 'lodash';
-import ShortcutTrigger from '../ShortcutTrigger';
+import React, { useState } from "react";
+import { omit } from "lodash";
+import ShortcutTrigger from "../ShortcutTrigger";
 
 const SelectionContext = React.createContext({});
 
-function SelectionProvider({
-  children,
-  initialSelected
-}: any) {
+function SelectionProvider({ children, initialSelected }: any) {
   const [selected, setSelected] = useState(initialSelected);
   const [intendedToSelect, setIntendedToSelect] = useState([]);
   const [currentSelectedType, setCurrentSelectedType] = useState(null);
@@ -18,7 +14,7 @@ function SelectionProvider({
   const updateSelectedData = (data = {}) => {
     setSelectedData({
       ...selectedData,
-      ...data
+      ...data,
     });
   };
 
@@ -28,7 +24,7 @@ function SelectionProvider({
       newSelected = selected.concat(id);
       setSelectedData({
         ...selectedData,
-        [id]: data
+        [id]: data,
       });
     } else {
       newSelected = selected.filter((existingId: any) => existingId !== id);
@@ -79,7 +75,7 @@ function SelectionProvider({
     intendedToSelect,
     lastInteracted,
     setLastInteracted,
-    updateSelectedData
+    updateSelectedData,
   };
   return (
     <SelectionContext.Provider value={sharedState}>
@@ -89,13 +85,8 @@ function SelectionProvider({
   );
 }
 
-SelectionProvider.propTypes = {
-  children: node.isRequired,
-  initialSelected: arrayOf(oneOfType([string, number]))
-};
-
 SelectionProvider.defaultProps = {
-  initialSelected: []
+  initialSelected: [],
 };
 
 export { SelectionProvider, SelectionContext };

--- a/lib/Shortcut/ShortcutIcon.tsx
+++ b/lib/Shortcut/ShortcutIcon.tsx
@@ -1,18 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function ShortcutIcon(props: any) {
-  return <span className="shortcut__keyboard">{props.children}</span>
+  return <span className="shortcut__keyboard">{props.children}</span>;
 }
-
-ShortcutIcon.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]),
-};
 
 ShortcutIcon.defaultProps = {
   children: [],

--- a/lib/Shortcut/index.tsx
+++ b/lib/Shortcut/index.tsx
@@ -1,26 +1,18 @@
 import React from "react";
-import PropTypes from "prop-types";
 
 export function Shortcut(props: any) {
-  return <div className="shortcut">
-    <div className={`shortcut__name ${props.styleClass}`}>{props.name}</div>
-    <div className="shortcut__wrapper">
-      {React.Children.map(props.children, (child: any, idx: any) => [
-        idx > 0 ? <span className="shortcut__plus">+</span> : null,
-        child,
-      ])}
+  return (
+    <div className="shortcut">
+      <div className={`shortcut__name ${props.styleClass}`}>{props.name}</div>
+      <div className="shortcut__wrapper">
+        {React.Children.map(props.children, (child: any, idx: any) => [
+          idx > 0 ? <span className="shortcut__plus">+</span> : null,
+          child,
+        ])}
+      </div>
     </div>
-  </div>
+  );
 }
-
-Shortcut.propTypes = {
-  name: PropTypes.string.isRequired,
-  styleClass: PropTypes.string,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]),
-};
 
 Shortcut.defaultProps = {
   styleClass: "",

--- a/lib/StatusIndicator/index.tsx
+++ b/lib/StatusIndicator/index.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import Icon from "../Icon";
 import TooltipWrapper from "../TooltipWrapper";
@@ -96,28 +95,6 @@ export function StatusIndicator({
     </div>
   );
 }
-
-StatusIndicator.propTypes = {
-  className: PropTypes.string,
-  color: PropTypes.string,
-  label: PropTypes.string,
-  children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  actions: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  completed: PropTypes.bool,
-  showDescription: PropTypes.bool,
-  description: PropTypes.string,
-  preText: PropTypes.string,
-  collapsed: PropTypes.bool,
-  small: PropTypes.bool,
-  medium: PropTypes.bool,
-  softLabel: PropTypes.bool,
-  bordered: PropTypes.bool,
-  readOnly: PropTypes.bool,
-  row: PropTypes.bool,
-  circleLarge: PropTypes.bool,
-  approved: PropTypes.bool,
-  labelFontSize: PropTypes.string,
-};
 
 StatusIndicator.defaultProps = {
   className: "",

--- a/lib/TabsNew/Tab.tsx
+++ b/lib/TabsNew/Tab.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useState, useRef } from "react";
-import { func, string, number } from "prop-types";
 import cx from "classnames";
 import { TabsContext } from "./index";
 import { TabsRowContext } from "./TabsRow";
@@ -56,11 +55,5 @@ function Tab({ children, id, index }: any) {
     </TabContext.Provider>
   );
 }
-
-Tab.propTypes = {
-  children: func.isRequired,
-  id: string.isRequired,
-  index: number.isRequired,
-};
 
 export { Tab, TabContext };

--- a/lib/TabsNew/TabAside.tsx
+++ b/lib/TabsNew/TabAside.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { node } from "prop-types";
 import cx from "classnames";
 import { TabContext } from "./Tab";
 
@@ -29,10 +28,5 @@ function TabAside({ children }: any) {
     </div>
   );
 }
-
-TabAside.propTypes = {
-  // eslint-disable-next-line react/require-default-props
-  children: node,
-};
 
 export { TabAside };

--- a/lib/TabsNew/TabDragLine.tsx
+++ b/lib/TabsNew/TabDragLine.tsx
@@ -1,15 +1,8 @@
-import React from 'react';
-import { string } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-export function TabDragLine({
-  side
-}: any) {
+export function TabDragLine({ side }: any) {
   const className = cx(`tab-drag-line absolute top-0 h-full z-10 ${side}`);
 
   return <span className={className} />;
 }
-
-TabDragLine.propTypes = {
-  side: string.isRequired
-};

--- a/lib/TabsNew/TabName.tsx
+++ b/lib/TabsNew/TabName.tsx
@@ -1,10 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-function TabName({
-  children,
-  className
-}: any) {
+function TabName({ children, className }: any) {
   return (
     <div
       className={`tab-name whitespace-nowrap overflow-hidden w-full ${className}`}
@@ -14,13 +10,8 @@ function TabName({
   );
 }
 
-TabName.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 TabName.defaultProps = {
-  className: ''
+  className: "",
 };
 
 export { TabName };

--- a/lib/TabsNew/TabNameForm.tsx
+++ b/lib/TabsNew/TabNameForm.tsx
@@ -1,5 +1,4 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
-import { string, func } from "prop-types";
 import cx from "classnames";
 import { TabContext } from "./Tab";
 import { Tabs, TabsContext } from "./index";
@@ -146,14 +145,6 @@ export function TabNameForm({
     </>
   );
 }
-
-TabNameForm.propTypes = {
-  placeholder: string,
-  initialName: string,
-  className: string,
-  setActiveTab: func.isRequired,
-  submitTabForm: func.isRequired,
-};
 
 TabNameForm.defaultProps = {
   placeholder: "Name this tab",

--- a/lib/TabsNew/TabOptions.tsx
+++ b/lib/TabsNew/TabOptions.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import cx from "classnames";
-import { node } from "prop-types";
 import { ButtonIcon } from "lib";
 import Dropdown from "../Dropdown";
 import { TabContext } from "./Tab";
@@ -40,7 +39,6 @@ function TabOptions({ children }: any) {
               {({ toggleShowContent }: any) => (
                 <ButtonIcon
                   name="cog16"
-                  // @ts-expect-error
                   tabIndex={0}
                   onClick={() => {
                     toggleShowContent();
@@ -62,9 +60,5 @@ function TabOptions({ children }: any) {
     </Dropdown>
   );
 }
-
-TabOptions.propTypes = {
-  children: node.isRequired,
-};
 
 export { TabOptions };

--- a/lib/TabsNew/TabsActionGroup.tsx
+++ b/lib/TabsNew/TabsActionGroup.tsx
@@ -1,10 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-function TabsActionGroup({
-  children,
-  className
-}: any) {
+function TabsActionGroup({ children, className }: any) {
   return (
     <div
       className={`tabs-action-group absolute right-0 mr-8 z-10 ${className}`}
@@ -16,11 +12,6 @@ function TabsActionGroup({
 
 export { TabsActionGroup };
 
-TabsActionGroup.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 TabsActionGroup.defaultProps = {
-  className: ''
+  className: "",
 };

--- a/lib/TabsNew/TabsGroup.tsx
+++ b/lib/TabsNew/TabsGroup.tsx
@@ -1,18 +1,13 @@
-import React from 'react';
-import { node, string, number } from 'prop-types';
-import cx from 'classnames';
+import React from "react";
+import cx from "classnames";
 
-function TabsGroup({
-  children,
-  className,
-  maxNumberOfVisibleRows
-}: any) {
+function TabsGroup({ children, className, maxNumberOfVisibleRows }: any) {
   const numberOfRows = children.length;
 
-  const tabsClassName = cx('tab-group', {
-    'max-h-30': maxNumberOfVisibleRows === 3,
-    'overflow-y-hidden': numberOfRows <= maxNumberOfVisibleRows,
-    'overflow-y-scroll': numberOfRows > maxNumberOfVisibleRows
+  const tabsClassName = cx("tab-group", {
+    "max-h-30": maxNumberOfVisibleRows === 3,
+    "overflow-y-hidden": numberOfRows <= maxNumberOfVisibleRows,
+    "overflow-y-scroll": numberOfRows > maxNumberOfVisibleRows,
   });
 
   return <nav className={`${tabsClassName} ${className}`}>{children}</nav>;
@@ -20,13 +15,7 @@ function TabsGroup({
 
 export { TabsGroup };
 
-TabsGroup.propTypes = {
-  children: node.isRequired,
-  className: string,
-  maxNumberOfVisibleRows: number
-};
-
 TabsGroup.defaultProps = {
-  className: '',
-  maxNumberOfVisibleRows: 3
+  className: "",
+  maxNumberOfVisibleRows: 3,
 };

--- a/lib/TabsNew/TabsRow.tsx
+++ b/lib/TabsNew/TabsRow.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { arrayOf, number, node } from "prop-types";
 import cx from "classnames";
 import { TabsContext } from "./index";
 
@@ -30,11 +29,6 @@ function TabsRow({ children, colCount }: any) {
     </TabsRowContext.Provider>
   );
 }
-
-TabsRow.propTypes = {
-  children: arrayOf(node).isRequired,
-  colCount: number,
-};
 
 TabsRow.defaultProps = {
   colCount: 8,

--- a/lib/TabsNew/TabsScrollShadow.tsx
+++ b/lib/TabsNew/TabsScrollShadow.tsx
@@ -1,31 +1,28 @@
-import React, { Fragment } from 'react';
-import { string } from 'prop-types';
-import { useSpring, animated } from 'react-spring';
+import React, { Fragment } from "react";
+import { useSpring, animated } from "react-spring";
 
-export function TabsScrollShadow({
-  scrollPosition
-}: any) {
+export function TabsScrollShadow({ scrollPosition }: any) {
   const shouldTopShadowBeVisible =
-    scrollPosition === 'bottom' || scrollPosition === 'middle';
+    scrollPosition === "bottom" || scrollPosition === "middle";
   const shouldBottomShadowBeVisible =
-    scrollPosition === 'top' || scrollPosition === 'middle';
+    scrollPosition === "top" || scrollPosition === "middle";
 
   const [propsTop, setTop] = useSpring(() => ({
-    opacity: shouldTopShadowBeVisible ? 1 : 0
+    opacity: shouldTopShadowBeVisible ? 1 : 0,
   }));
   const [propsBottom, setBottom] = useSpring(() => ({
-    opacity: shouldBottomShadowBeVisible ? 1 : 0
+    opacity: shouldBottomShadowBeVisible ? 1 : 0,
   }));
 
   setTop({
-    opacity: shouldTopShadowBeVisible ? 1 : 0
+    opacity: shouldTopShadowBeVisible ? 1 : 0,
   });
 
   setBottom({
-    opacity: shouldBottomShadowBeVisible ? 1 : 0
+    opacity: shouldBottomShadowBeVisible ? 1 : 0,
   });
 
-  const initialClassName = 'absolute w-full h-4 -mr-4 pointer-events-none z-20';
+  const initialClassName = "absolute w-full h-4 -mr-4 pointer-events-none z-20";
 
   return (
     <>
@@ -40,7 +37,3 @@ export function TabsScrollShadow({
     </>
   );
 }
-
-TabsScrollShadow.propTypes = {
-  scrollPosition: string.isRequired
-};

--- a/lib/TabsNew/index.tsx
+++ b/lib/TabsNew/index.tsx
@@ -1,41 +1,35 @@
-import React, { useState } from 'react';
-import { node, string, number } from 'prop-types';
-import { Tab, TabContext } from './Tab';
-import { TabsActionGroup } from './TabsActionGroup';
-import { TabsGroup } from './TabsGroup';
-import { TabsScrollShadow } from './TabsScrollShadow';
-import { TabDragLine } from './TabDragLine';
-import { TabName } from './TabName';
-import { TabAside } from './TabAside';
-import { TabOptions } from './TabOptions';
-import { TabsRow } from './TabsRow';
-import { TabNameForm } from './TabNameForm';
+import React, { useState } from "react";
+import { Tab, TabContext } from "./Tab";
+import { TabsActionGroup } from "./TabsActionGroup";
+import { TabsGroup } from "./TabsGroup";
+import { TabsScrollShadow } from "./TabsScrollShadow";
+import { TabDragLine } from "./TabDragLine";
+import { TabName } from "./TabName";
+import { TabAside } from "./TabAside";
+import { TabOptions } from "./TabOptions";
+import { TabsRow } from "./TabsRow";
+import { TabNameForm } from "./TabNameForm";
 
 const TabsContext = React.createContext({});
 
-function Tabs({
-  children,
-  className,
-  tabsLength,
-  activeTabId
-}: any) {
-  const [scrollPosition, setScrollPosition] = useState('top');
+function Tabs({ children, className, tabsLength, activeTabId }: any) {
+  const [scrollPosition, setScrollPosition] = useState("top");
 
   const sharedState = {
     activeTabId,
-    tabsLength
+    tabsLength,
   };
 
   return (
     <TabsContext.Provider value={sharedState}>
       <div
-        onScroll={e => {
+        onScroll={(e) => {
           const element = e.target;
 
           // @ts-expect-error TS(2339): Property 'scrollTop' does not exist on type 'Event... Remove this comment to see the full error message
           if (element.scrollTop === 0) {
-            if (scrollPosition !== 'top') {
-              setScrollPosition('top');
+            if (scrollPosition !== "top") {
+              setScrollPosition("top");
             }
           } else if (
             // @ts-expect-error TS(2339): Property 'scrollHeight' does not exist on type 'Ev... Remove this comment to see the full error message
@@ -43,11 +37,11 @@ function Tabs({
             // @ts-expect-error TS(2339): Property 'clientHeight' does not exist on type 'Ev... Remove this comment to see the full error message
             element.clientHeight
           ) {
-            if (scrollPosition !== 'bottom') {
-              setScrollPosition('bottom');
+            if (scrollPosition !== "bottom") {
+              setScrollPosition("bottom");
             }
-          } else if (scrollPosition !== 'middle') {
-            setScrollPosition('middle');
+          } else if (scrollPosition !== "middle") {
+            setScrollPosition("middle");
           }
         }}
         className={`tabs-new relative ${className} ${scrollPosition}`}
@@ -73,15 +67,8 @@ Tabs.TabNameForm = TabNameForm;
 Tabs.TabAside = TabAside;
 Tabs.TabOptions = TabOptions;
 
-Tabs.propTypes = {
-  tabsLength: number.isRequired,
-  activeTabId: string.isRequired,
-  children: node.isRequired,
-  className: string
-};
-
 Tabs.defaultProps = {
-  className: ''
+  className: "",
 };
 
 export { Tabs, TabsContext };

--- a/lib/Toolbar/Toolbar.tsx
+++ b/lib/Toolbar/Toolbar.tsx
@@ -1,12 +1,7 @@
-import React from 'react';
-import { node, string } from 'prop-types';
-import { Divider } from './Divider';
+import React from "react";
+import { Divider } from "./Divider";
 
-function Toolbar({
-  children,
-  className,
-  ...rest
-}: any) {
+function Toolbar({ children, className, ...rest }: any) {
   return (
     <div
       className={`flex items-center border-0 border-b border-solid border-neutral-90 px-4 bg-white ${className}`}
@@ -17,13 +12,8 @@ function Toolbar({
   );
 }
 
-Toolbar.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 Toolbar.defaultProps = {
-  className: ''
+  className: "",
 };
 
 Toolbar.Divider = Divider;

--- a/lib/TopBar/TopBarCell.tsx
+++ b/lib/TopBar/TopBarCell.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 
 export function TopBarCell(props: any) {
@@ -8,17 +7,6 @@ export function TopBarCell(props: any) {
   });
   return <div className={classes}>{props.children}</div>;
 }
-
-TopBarCell.propTypes = {
-  bordered: PropTypes.bool,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]),
-  className: PropTypes.string,
-};
 
 TopBarCell.defaultProps = {
   bordered: false,

--- a/lib/TopBar/TopBarContent.tsx
+++ b/lib/TopBar/TopBarContent.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import { Col } from "lib";
 
@@ -23,20 +22,6 @@ export function TopBarContent({
     </Col>
   );
 }
-
-TopBarContent.propTypes = {
-  left: PropTypes.bool,
-  center: PropTypes.bool,
-  right: PropTypes.bool,
-  collapse: PropTypes.bool,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]),
-  className: PropTypes.string,
-};
 
 TopBarContent.defaultProps = {
   left: false,

--- a/lib/TopBar/TopBarGroup.tsx
+++ b/lib/TopBar/TopBarGroup.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 
 export function TopBarGroup(props: any) {
@@ -8,16 +7,6 @@ export function TopBarGroup(props: any) {
   });
   return <div className={classes}>{props.children}</div>;
 }
-
-TopBarGroup.propTypes = {
-  collapse: PropTypes.bool,
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    PropTypes.arrayOf(PropTypes.shape()),
-  ]),
-};
 
 TopBarGroup.defaultProps = {
   collapse: false,

--- a/lib/TopBar/index.tsx
+++ b/lib/TopBar/index.tsx
@@ -12,7 +12,7 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   fixed?: boolean;
   scrollToFixed?: boolean;
   useDarkTheme?: boolean;
-  notification?: ReactNode;
+  notification?: ReactNode | JSX.Element;
   shadow?: boolean;
   useLightGreyTheme?: boolean;
 }

--- a/lib/TreeLines/index.tsx
+++ b/lib/TreeLines/index.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-// @ts-expect-error TS(2305): Module '"prop-types"' has no exported member 'Prop... Remove this comment to see the full error message
-import { PropTypes } from "prop-types";
 import { uniqueId } from "lodash";
 
 export function TreeLine() {
-  return <span className="treelines__line" />
+  return <span className="treelines__line" />;
 }
 
 export function TreeLines({ quantity = 0 }) {
@@ -14,10 +12,6 @@ export function TreeLines({ quantity = 0 }) {
   }
   return <div className="treelines">{lines}</div>;
 }
-
-TreeLines.propTypes = {
-  quantity: PropTypes.number,
-};
 
 TreeLines.defaultProps = {
   quantity: 0,

--- a/lib/UserSearch/UserSearchHead.tsx
+++ b/lib/UserSearch/UserSearchHead.tsx
@@ -1,46 +1,39 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import CheckToggle from '../CheckToggle';
+import React from "react";
+import CheckToggle from "../CheckToggle";
 
 function UserSearchHead({
   searchHeading,
   subheading,
   useDisplayToggle,
   toggleListDisplay,
-  toggleActive
+  toggleActive,
 }: any) {
-  return <div className="user-search__search-head">
-    <div className="user-search__search-head-top">
-      {searchHeading && (
-        <span className="user-search__search-heading">{searchHeading}</span>
-      )}
-      {useDisplayToggle && (
-        <CheckToggle
-          id="userSearchToggle"
-          displaySmall
-          displayChecked
-          clickHandler={toggleListDisplay}
-          checked={toggleActive}
-        />
+  return (
+    <div className="user-search__search-head">
+      <div className="user-search__search-head-top">
+        {searchHeading && (
+          <span className="user-search__search-heading">{searchHeading}</span>
+        )}
+        {useDisplayToggle && (
+          <CheckToggle
+            id="userSearchToggle"
+            displaySmall
+            displayChecked
+            clickHandler={toggleListDisplay}
+            checked={toggleActive}
+          />
+        )}
+      </div>
+      {subheading && (
+        <span className="user-search__search-subheading">{subheading}</span>
       )}
     </div>
-    {subheading && (
-      <span className="user-search__search-subheading">{subheading}</span>
-    )}
-  </div>
+  );
 }
-
-UserSearchHead.propTypes = {
-  searchHeading: PropTypes.string,
-  useDisplayToggle: PropTypes.bool.isRequired,
-  subheading: PropTypes.string,
-  toggleListDisplay: PropTypes.func.isRequired,
-  toggleActive: PropTypes.bool.isRequired
-};
 
 UserSearchHead.defaultProps = {
   subheading: null,
-  searchHeading: ''
+  searchHeading: "",
 };
 
 export default UserSearchHead;

--- a/lib/UserSearch/UserSearchList.tsx
+++ b/lib/UserSearch/UserSearchList.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Dropdown from "../Dropdown";
 import Avatar from "../Avatar";
 import AvatarInformation from "../Avatar/AvatarInformation";
@@ -54,19 +53,5 @@ function UserSearchList({
     </ul>
   );
 }
-
-UserSearchList.propTypes = {
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  users: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  addUser: PropTypes.func.isRequired,
-  displayEmail: PropTypes.bool.isRequired,
-  selectedUserIds: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-  ).isRequired,
-  noUsers: PropTypes.bool.isRequired,
-  noUserDisplay: PropTypes.oneOfType([PropTypes.node, PropTypes.string])
-    .isRequired,
-  hideAfterPerformingAction: PropTypes.bool.isRequired,
-};
 
 export default UserSearchList;

--- a/lib/UserSearch/UserSearchListUserName.tsx
+++ b/lib/UserSearch/UserSearchListUserName.tsx
@@ -1,14 +1,10 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import cx from 'classnames';
-import Icon from '../Icon';
+import React from "react";
+import cx from "classnames";
+import Icon from "../Icon";
 
-function UserSearchListUserName({
-  name,
-  isSelected
-}: any) {
-  const classes = cx('user-search-list__user-name', {
-    'is-active': isSelected
+function UserSearchListUserName({ name, isSelected }: any) {
+  const classes = cx("user-search-list__user-name", {
+    "is-active": isSelected,
   });
   return (
     <div className={classes}>
@@ -17,10 +13,5 @@ function UserSearchListUserName({
     </div>
   );
 }
-
-UserSearchListUserName.propTypes = {
-  name: PropTypes.string.isRequired,
-  isSelected: PropTypes.bool.isRequired
-};
 
 export default UserSearchListUserName;

--- a/lib/UserSearchDropdown/index.tsx
+++ b/lib/UserSearchDropdown/index.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import Dropdown from "../Dropdown";
 import Icon from "../Icon";
 import TooltipWrapper from "../TooltipWrapper";
@@ -56,19 +55,6 @@ export class UserSearchDropdown extends Component {
     );
   }
 }
-
-// @ts-expect-error TS(2339): Property 'propTypes' does not exist on type 'typeo... Remove this comment to see the full error message
-UserSearchDropdown.propTypes = {
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  users: PropTypes.arrayOf(PropTypes.shape()).isRequired,
-  addUser: PropTypes.func.isRequired,
-  displayEmail: PropTypes.bool.isRequired,
-  dropdownAutoPosition: PropTypes.bool.isRequired,
-  searchHeading: PropTypes.string,
-  tooltipText: PropTypes.string,
-  className: PropTypes.string,
-  useAtIcon: PropTypes.bool,
-};
 
 // @ts-expect-error TS(2339): Property 'defaultProps' does not exist on type 'ty... Remove this comment to see the full error message
 UserSearchDropdown.defaultProps = {

--- a/lib/Windowing/Windowing.tsx
+++ b/lib/Windowing/Windowing.tsx
@@ -1,5 +1,4 @@
-import React, { useState, createContext, useEffect } from 'react';
-import { node, number, arrayOf, string, oneOfType } from 'prop-types';
+import React, { useState, createContext, useEffect } from "react";
 
 export const WindowingContext = createContext({});
 
@@ -9,7 +8,7 @@ function Windowing({
   debounceTimer,
   itemHeight,
   buffer,
-  allIds
+  allIds,
 }: any) {
   const [scrollTop, setScrollTop] = useState(null);
   const [height, setHeight] = useState(null);
@@ -34,7 +33,7 @@ function Windowing({
 
     setRenderIndexes({
       offset: startWithBuffer,
-      length: endWithBuffer - startWithBuffer
+      length: endWithBuffer - startWithBuffer,
     });
   };
 
@@ -46,14 +45,14 @@ function Windowing({
     renderIndexes,
     itemHeight,
     baseItemStyle: {
-      height: `${itemHeight}px`
+      height: `${itemHeight}px`,
     },
     setHeight,
     debounceTimer,
     containerHeight,
     inViewWindowingIds,
     setInViewWindowingIds,
-    allWindowingIds: allIds
+    allWindowingIds: allIds,
   };
 
   return (
@@ -63,19 +62,10 @@ function Windowing({
   );
 }
 
-Windowing.propTypes = {
-  children: node.isRequired,
-  itemHeight: number.isRequired,
-  debounceTimer: number,
-  containerHeight: oneOfType([string, number]),
-  buffer: number,
-  allIds: arrayOf(oneOfType([string, number])).isRequired
-};
-
 Windowing.defaultProps = {
   debounceTimer: 15,
-  containerHeight: '',
-  buffer: 10
+  containerHeight: "",
+  buffer: 10,
 };
 
 export { Windowing };

--- a/lib/Windowing/WindowingItem.tsx
+++ b/lib/Windowing/WindowingItem.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { node, number, shape } from "prop-types";
 import { WindowingContext } from "./Windowing";
 
 function WindowingItem({ children, index, style }: any) {
@@ -19,12 +18,6 @@ function WindowingItem({ children, index, style }: any) {
     </div>
   );
 }
-
-WindowingItem.propTypes = {
-  children: node.isRequired,
-  index: number.isRequired,
-  style: shape({}),
-};
 
 WindowingItem.defaultProps = {
   style: {},

--- a/lib/Windowing/WindowingList.tsx
+++ b/lib/Windowing/WindowingList.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { func } from "prop-types";
 import { WindowingContext } from "./Windowing";
 
 function WindowingList({ children, ...rest }: any) {
@@ -18,9 +17,5 @@ function WindowingList({ children, ...rest }: any) {
     </div>
   );
 }
-
-WindowingList.propTypes = {
-  children: func.isRequired,
-};
 
 export { WindowingList };

--- a/lib/Windowing/WindowingScroller.tsx
+++ b/lib/Windowing/WindowingScroller.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useContext, useEffect } from "react";
-import { node, shape } from "prop-types";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'debo... Remove this comment to see the full error message
 import debounce from "debounce";
 import { WindowingContext } from "./Windowing";
@@ -53,12 +52,6 @@ function WindowingScroller({ children, style, ...rest }: any) {
     </div>
   );
 }
-
-WindowingScroller.propTypes = {
-  children: node.isRequired,
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  style: shape(),
-};
 
 WindowingScroller.defaultProps = {
   style: {},

--- a/lib/Windowing/stories/FlatWindowing.stories.tsx
+++ b/lib/Windowing/stories/FlatWindowing.stories.tsx
@@ -11,7 +11,6 @@ export function Flat() {
   }));
 
   return (
-    // @ts-expect-error TS(2322): Type '{ id: number; }[]' is not assignable to type... Remove this comment to see the full error message
     <Windowing itemHeight={50} allIds={items} containerHeight="800px">
       {/* @ts-expect-error TS(2339): Property 'Scroller' does not exist on type '{ ({ c... Remove this comment to see the full error message */}
       <Windowing.Scroller>

--- a/lib/Windowing/stories/NestedWindoing.stories.tsx
+++ b/lib/Windowing/stories/NestedWindoing.stories.tsx
@@ -43,7 +43,7 @@ export function Nested({ parents, children }: any) {
                       </ItemRow>
                     ) : (
                       <FolderRow open>
-                        {(show, setShow) => (
+                        {(show: any, setShow: any) => (
                           // @ts-expect-error TS(2339): Property 'Inner' does not exist on type 'typeof Fo... Remove this comment to see the full error message
                           <FolderRow.Inner style={{ minWidth: "320px" }}>
                             {/* @ts-expect-error TS(2339): Property 'Name' does not exist on type 'typeof Fol... Remove this comment to see the full error message */}

--- a/lib/Windowing/tests/Windowing.spec.tsx
+++ b/lib/Windowing/tests/Windowing.spec.tsx
@@ -15,7 +15,6 @@ describe("Windowing", () => {
   });
 
   const createFlatWrapper = () => (
-    // @ts-expect-error TS(2709): Cannot use namespace 'Windowing' as a type.
     <Windowing allIds={items} itemHeight={10} containerHeight={50} buffer={10}>
       {/* @ts-expect-error TS(2694): Namespace 'Windowing' has no exported member 'Scro... Remove this comment to see the full error message */}
       <Windowing.Scroller>

--- a/lib/images/ImageLoader/index.tsx
+++ b/lib/images/ImageLoader/index.tsx
@@ -1,19 +1,8 @@
 import React, { PureComponent } from "react";
-import PropTypes from "prop-types";
 import cx from "classnames";
 import Icon from "../../Icon";
 
 export class ImageLoader extends PureComponent {
-  static propTypes = {
-    alt: PropTypes.string.isRequired,
-    src: PropTypes.string.isRequired,
-    loadTransition: PropTypes.bool,
-    // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-    preLoadedStyles: PropTypes.shape(),
-    onLoad: PropTypes.func,
-    onError: PropTypes.func,
-  };
-
   static defaultProps = {
     loadTransition: false,
     preLoadedStyles: {},

--- a/lib/src/components/animated/AnimatedWrapper.stories.tsx
+++ b/lib/src/components/animated/AnimatedWrapper.stories.tsx
@@ -25,7 +25,6 @@ export function AnimatedWrapper() {
     >
       <AnimatedWrapperComponent
         animatableProperties={animatableProperties}
-        // @ts-expect-error
         className="min-w-30 absolute"
       >
         <ButtonPrimary

--- a/lib/src/components/animated/AnimatedWrapper.tsx
+++ b/lib/src/components/animated/AnimatedWrapper.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
-import { shape, number, node } from 'prop-types';
-import { useSpring, animated } from 'react-spring';
+import React from "react";
+import { useSpring, animated } from "react-spring";
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'd3-e... Remove this comment to see the full error message
-import * as easings from 'd3-ease';
+import * as easings from "d3-ease";
 
 export function AnimatedWrapper({
   animatableProperties,
@@ -14,8 +13,8 @@ export function AnimatedWrapper({
     ...animatableProperties,
     config: {
       easing: easings.easeCubic,
-      duration
-    }
+      duration,
+    },
   });
 
   return (
@@ -25,14 +24,7 @@ export function AnimatedWrapper({
   );
 }
 
-AnimatedWrapper.propTypes = {
-  // @ts-expect-error TS(2554): Expected 1 arguments, but got 0.
-  animatableProperties: shape(),
-  duration: number,
-  children: node.isRequired
-};
-
 AnimatedWrapper.defaultProps = {
   animatableProperties: {},
-  duration: 300
+  duration: 300,
 };

--- a/lib/src/components/card/Card.tsx
+++ b/lib/src/components/card/Card.tsx
@@ -1,12 +1,11 @@
-import React from 'react';
-import { bool, func, string } from 'prop-types';
-import cx from 'classnames';
-import { CardContent } from './CardContent';
-import { CardControls } from './CardControls';
-import { CardTitle } from './CardTitle';
-import { CardDescription } from './CardDescription';
-import { CardFooter } from './CardFooter';
-import { cardSizes } from './common';
+import React from "react";
+import cx from "classnames";
+import { CardContent } from "./CardContent";
+import { CardControls } from "./CardControls";
+import { CardTitle } from "./CardTitle";
+import { CardDescription } from "./CardDescription";
+import { CardFooter } from "./CardFooter";
+import { cardSizes } from "./common";
 
 function Card({
   onClick,
@@ -19,31 +18,31 @@ function Card({
   removed,
   active,
   disabled,
-  size
+  size,
 }: any) {
-  const classNames = cx('card outline-none', className, {
-    'card-interactive': onClick,
-    'card-selected': selected,
-    'card-highlighted': highlighted,
-    'card-added': added,
-    'card-removed': removed,
-    'card-disabled': disabled,
-    'card-active': active,
-    'card-sm': size === cardSizes.sm,
-    'card-md': size === cardSizes.md
+  const classNames = cx("card outline-none", className, {
+    "card-interactive": onClick,
+    "card-selected": selected,
+    "card-highlighted": highlighted,
+    "card-added": added,
+    "card-removed": removed,
+    "card-disabled": disabled,
+    "card-active": active,
+    "card-sm": size === cardSizes.sm,
+    "card-md": size === cardSizes.md,
   });
 
-  const innerClasses = cx('card-inner', innerClassNames);
+  const innerClasses = cx("card-inner", innerClassNames);
 
   const handleKeyPress = (e: any) => {
-    if (e.key === 'Enter') {
+    if (e.key === "Enter") {
       onClick(e);
     }
   };
 
   return (
     <div // eslint-disable-line jsx-a11y/no-static-element-interactions
-      role={onClick ? 'button' : 'presentation'}
+      role={onClick ? "button" : "presentation"}
       className={classNames}
       onClick={onClick}
       onKeyUp={handleKeyPress}
@@ -59,28 +58,16 @@ Card.Description = CardDescription;
 Card.Controls = CardControls;
 Card.Footer = CardFooter;
 
-Card.propTypes = {
-  onClick: func,
-  innerClassNames: string,
-  selected: bool,
-  highlighted: bool,
-  added: bool,
-  removed: bool,
-  disabled: bool,
-  active: bool,
-  size: string
-};
-
 Card.defaultProps = {
   onClick: null,
-  innerClassNames: '',
+  innerClassNames: "",
   selected: false,
   highlighted: false,
   added: false,
   removed: false,
   disabled: false,
   active: false,
-  size: ''
+  size: "",
 };
 
 export { Card };

--- a/lib/src/components/form/Form.tsx
+++ b/lib/src/components/form/Form.tsx
@@ -1,14 +1,13 @@
-import * as React from 'react';
-import { bool, func } from 'prop-types';
-import cx from 'classnames';
-import { FormSubmission } from './FormSubmission';
-import { FormSubmitButton } from './FormSubmitButton';
-import { FormCancelButton } from './FormCancelButton';
-import { FormHelper } from './FormHelper';
-import { FormInput } from './FormInput';
-import { FormBody } from './FormBody';
-import { FormFieldset } from './FormFieldset';
-import { FormLegend } from './FormLegend';
+import * as React from "react";
+import cx from "classnames";
+import { FormSubmission } from "./FormSubmission";
+import { FormSubmitButton } from "./FormSubmitButton";
+import { FormCancelButton } from "./FormCancelButton";
+import { FormHelper } from "./FormHelper";
+import { FormInput } from "./FormInput";
+import { FormBody } from "./FormBody";
+import { FormFieldset } from "./FormFieldset";
+import { FormLegend } from "./FormLegend";
 
 interface Props extends React.FormHTMLAttributes<HTMLFormElement> {
   inline: boolean;
@@ -17,10 +16,10 @@ interface Props extends React.FormHTMLAttributes<HTMLFormElement> {
 export const FormContext = React.createContext({});
 
 export const statuses = {
-  idle: 'FORM_STATUS_IDLE',
-  processing: 'FORM_STATUS_SUBMITTING',
-  failure: 'FORM_STATUS_FAILURE',
-  success: 'FORM_STATUS_SUCCESS',
+  idle: "FORM_STATUS_IDLE",
+  processing: "FORM_STATUS_SUBMITTING",
+  failure: "FORM_STATUS_FAILURE",
+  success: "FORM_STATUS_SUCCESS",
 };
 
 const nonSubmittableStatuses = [statuses.processing, statuses.success];
@@ -29,14 +28,14 @@ export function Form({
   children,
   onSubmit,
   inline,
-  className = '',
+  className = "",
   ...rest
 }: Props) {
   const [status, setStatus] = React.useState(statuses.idle);
   const timeoutRef = React.useRef(0);
 
-  const classNames = cx('form', className, {
-    'form-inline': inline,
+  const classNames = cx("form", className, {
+    "form-inline": inline,
   });
 
   const sharedState = {
@@ -82,11 +81,6 @@ export function Form({
     </form>
   );
 }
-
-Form.propTypes = {
-  onSubmit: func.isRequired,
-  inline: bool,
-};
 
 Form.defaultProps = {
   inline: false,

--- a/lib/src/components/sidebar/Sidebar.stories.tsx
+++ b/lib/src/components/sidebar/Sidebar.stories.tsx
@@ -49,83 +49,84 @@ function ExampleOfUsingShowMoreToggle() {
 }
 
 export function Sidebar() {
-  return <SidebarComponent>
-    <SidebarComponent.Header onClose={() => {}}>
-      <h2>SidebarComponent header</h2>
-    </SidebarComponent.Header>
+  return (
+    <SidebarComponent>
+      <SidebarComponent.Header onClose={() => {}}>
+        <h2>SidebarComponent header</h2>
+      </SidebarComponent.Header>
 
-    <SidebarComponent.Body>
-      <SidebarComponent.Section>
-        <SidebarComponent.SectionHead>
-          <SidebarComponent.Heading>
-            <h3>Meta</h3>
-          </SidebarComponent.Heading>
-        </SidebarComponent.SectionHead>
+      <SidebarComponent.Body>
+        <SidebarComponent.Section>
+          <SidebarComponent.SectionHead>
+            <SidebarComponent.Heading>
+              <h3>Meta</h3>
+            </SidebarComponent.Heading>
+          </SidebarComponent.SectionHead>
 
-        <SidebarComponent.SubSection>
-          <SidebarComponent.SubHeading>
-            <h4>Alt text</h4>
-          </SidebarComponent.SubHeading>
-          Alt text value
-        </SidebarComponent.SubSection>
-      </SidebarComponent.Section>
+          <SidebarComponent.SubSection>
+            <SidebarComponent.SubHeading>
+              <h4>Alt text</h4>
+            </SidebarComponent.SubHeading>
+            Alt text value
+          </SidebarComponent.SubSection>
+        </SidebarComponent.Section>
 
-      <SidebarComponent.Section>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; toggle: Element; }' i... Remove this comment to see the full error message */}
-        <SidebarComponent.SectionHead
-          toggle={
-            <SidebarComponent.SectionToggle
-              hideText="Less info"
-              showText="More info"
-            />
-          }
-        >
-          <SidebarComponent.Heading>
-            <h4>Crop</h4>
-          </SidebarComponent.Heading>
-          <SidebarComponent.Description>
-            Set width or height values in pixels, Aspect ratio is always
-            honoured.
-          </SidebarComponent.Description>
-        </SidebarComponent.SectionHead>
+        <SidebarComponent.Section>
+          <SidebarComponent.SectionHead
+            toggle={
+              <SidebarComponent.SectionToggle
+                hideText="Less info"
+                showText="More info"
+              />
+            }
+          >
+            <SidebarComponent.Heading>
+              <h4>Crop</h4>
+            </SidebarComponent.Heading>
+            <SidebarComponent.Description>
+              Set width or height values in pixels, Aspect ratio is always
+              honoured.
+            </SidebarComponent.Description>
+          </SidebarComponent.SectionHead>
 
-        <SidebarComponent.SubSection>
-          <SidebarComponent.SubHeading>
-            <h4>Aspect ratio</h4>
-          </SidebarComponent.SubHeading>
-          16:9
-        </SidebarComponent.SubSection>
+          <SidebarComponent.SubSection>
+            <SidebarComponent.SubHeading>
+              <h4>Aspect ratio</h4>
+            </SidebarComponent.SubHeading>
+            16:9
+          </SidebarComponent.SubSection>
 
-        <SidebarComponent.SubSection>
-          <SidebarComponent.SubHeading>
-            <h4>Direction</h4>
-          </SidebarComponent.SubHeading>
-          Vertical
-        </SidebarComponent.SubSection>
+          <SidebarComponent.SubSection>
+            <SidebarComponent.SubHeading>
+              <h4>Direction</h4>
+            </SidebarComponent.SubHeading>
+            Vertical
+          </SidebarComponent.SubSection>
 
-        <SidebarComponent.SubSection>
-          <SidebarComponent.SubHeading>
-            <h4>Aspect ratio</h4>
-          </SidebarComponent.SubHeading>
-          16:9
-        </SidebarComponent.SubSection>
+          <SidebarComponent.SubSection>
+            <SidebarComponent.SubHeading>
+              <h4>Aspect ratio</h4>
+            </SidebarComponent.SubHeading>
+            16:9
+          </SidebarComponent.SubSection>
 
-        <ExampleOfUsingShowMoreToggle />
-      </SidebarComponent.Section>
-    </SidebarComponent.Body>
+          <ExampleOfUsingShowMoreToggle />
+        </SidebarComponent.Section>
+      </SidebarComponent.Body>
 
-    <SidebarComponent.Footer>
-      <a href="/" className="mr-auto">
-        <Icon name="help" />
-      </a>
-      <ButtonTertiary size="sm" onClick={() => {}} className="mr-2">
-        Cancel
-      </ButtonTertiary>
-      <ButtonPrimary size="sm" onClick={() => {}}>
-        Save
-      </ButtonPrimary>
-    </SidebarComponent.Footer>
-  </SidebarComponent>
+      <SidebarComponent.Footer>
+        <a href="/" className="mr-auto">
+          <Icon name="help" />
+        </a>
+        <ButtonTertiary size="sm" onClick={() => {}} className="mr-2">
+          Cancel
+        </ButtonTertiary>
+        <ButtonPrimary size="sm" onClick={() => {}}>
+          Save
+        </ButtonPrimary>
+      </SidebarComponent.Footer>
+    </SidebarComponent>
+  );
 }
 
 Sidebar.parameters = {

--- a/lib/src/components/sidebar/SidebarHeading.tsx
+++ b/lib/src/components/sidebar/SidebarHeading.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import { bool } from 'prop-types';
+import * as React from "react";
 
 export function SidebarHeading({
   children,
-  className = '',
+  className = "",
   showMoreToggle,
   ...rest
 }: any) {
@@ -14,10 +13,6 @@ export function SidebarHeading({
   );
 }
 
-SidebarHeading.propTypes = {
-  showMoreToggle: bool
-};
-
 SidebarHeading.defaultProps = {
-  showMoreToggle: false
+  showMoreToggle: false,
 };

--- a/lib/src/components/sidebar/SidebarSection.tsx
+++ b/lib/src/components/sidebar/SidebarSection.tsx
@@ -1,33 +1,28 @@
-import * as React from 'react';
-import { bool } from 'prop-types';
+import * as React from "react";
 
 export const SidebarSectionContext = React.createContext({});
 
 export function SidebarSection({
   children,
   initialShowMore,
-  className = '',
+  className = "",
   ...rest
 }: any) {
   const [showMore, setShowMore] = React.useState(initialShowMore);
   const sharedState = {
     showMore,
-    setShowMore
+    setShowMore,
   };
 
   return (
     <SidebarSectionContext.Provider value={sharedState}>
       <div className={`sidebar-section ${className}`} {...rest}>
-        {typeof children === 'function' ? children(sharedState) : children}
+        {typeof children === "function" ? children(sharedState) : children}
       </div>
     </SidebarSectionContext.Provider>
   );
 }
 
-SidebarSection.propTypes = {
-  initialShowMore: bool
-};
-
 SidebarSection.defaultProps = {
-  initialShowMore: false
+  initialShowMore: false,
 };

--- a/lib/src/components/sidebar/SidebarSectionHead.tsx
+++ b/lib/src/components/sidebar/SidebarSectionHead.tsx
@@ -1,15 +1,14 @@
-import * as React from 'react';
-import cx from 'classnames';
-import { node } from 'prop-types';
+import * as React from "react";
+import cx from "classnames";
 
 export function SidebarSectionHead({
   toggle,
   children,
-  className = '',
+  className = "",
   ...rest
 }: any) {
   const layoutClasses = cx({
-    'pr-2': toggle
+    "pr-2": toggle,
   });
 
   return (
@@ -21,10 +20,6 @@ export function SidebarSectionHead({
   );
 }
 
-SidebarSectionHead.propTypes = {
-  toggle: node
-};
-
 SidebarSectionHead.defaultProps = {
-  toggle: null
+  toggle: null,
 };

--- a/lib/src/components/sidebar/SidebarSectionToggle.tsx
+++ b/lib/src/components/sidebar/SidebarSectionToggle.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { ButtonSecondary } from "lib";
-import { string } from "prop-types";
 import { SidebarSectionContext } from "./SidebarSection";
 
 export function SidebarSectionToggle({
@@ -25,11 +24,6 @@ export function SidebarSectionToggle({
     </ButtonSecondary>
   );
 }
-
-SidebarSectionToggle.propTypes = {
-  showText: string,
-  hideText: string,
-};
 
 SidebarSectionToggle.defaultProps = {
   showText: "Show",

--- a/lib/src/modules/Button/ButtonAvatar/ButtonAvatar.tsx
+++ b/lib/src/modules/Button/ButtonAvatar/ButtonAvatar.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { string, bool } from "prop-types";
 import { Avatar } from "lib";
 import cx from "classnames";
 import { ButtonBase } from "../ButtonBase";
@@ -22,14 +21,6 @@ export function ButtonAvatar({
     </ButtonBase>
   );
 }
-
-ButtonAvatar.propTypes = {
-  initials: string.isRequired,
-  url: string,
-  disabled: bool,
-  className: string,
-  active: bool,
-};
 
 ButtonAvatar.defaultProps = {
   url: "",

--- a/lib/src/modules/Button/ButtonBase.tsx
+++ b/lib/src/modules/Button/ButtonBase.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/button-has-type */
 import React from "react";
 import cx from "classnames";
-import { arrayOf, bool, oneOfType, string } from "prop-types";
 import { Icon } from "lib";
-import { defaultProps, propTypes, sizes } from "./common";
+import { defaultProps, sizes } from "./common";
 
 export function ButtonBase({
   children,
@@ -53,13 +52,6 @@ export function ButtonBase({
     </button>
   );
 }
-
-ButtonBase.propTypes = {
-  ...propTypes,
-  disabled: bool,
-  loaderTypes: arrayOf(string),
-  size: oneOfType([string, bool]),
-};
 
 ButtonBase.defaultProps = {
   ...defaultProps,

--- a/lib/src/modules/Button/ButtonIcon/ButtonIcon.tsx
+++ b/lib/src/modules/Button/ButtonIcon/ButtonIcon.tsx
@@ -1,14 +1,8 @@
 import React from "react";
-import { bool } from "prop-types";
 import cx from "classnames";
 import { Icon } from "lib";
 import { ButtonBase } from "../ButtonBase";
-import {
-  sizes,
-  getSizeClasses,
-  buttonIconPropTypes,
-  buttonIconDefaultProps,
-} from "../common";
+import { sizes, getSizeClasses, buttonIconDefaultProps } from "../common";
 
 function ButtonIcon({
   className,
@@ -50,11 +44,6 @@ function ButtonIcon({
 }
 
 ButtonIcon.sizes = sizes;
-
-ButtonIcon.propTypes = {
-  ...buttonIconPropTypes,
-  enabled: bool,
-};
 
 ButtonIcon.defaultProps = {
   ...buttonIconDefaultProps,

--- a/lib/src/modules/Button/ButtonIcon/ButtonIconBubble.tsx
+++ b/lib/src/modules/Button/ButtonIcon/ButtonIconBubble.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ButtonIcon } from "lib";
 import cx from "classnames";
-import { buttonIconPropTypes, buttonIconDefaultProps } from "../common";
+import { buttonIconDefaultProps } from "../common";
 
 export function ButtonIconBubble({
   className,
@@ -28,8 +28,6 @@ export function ButtonIconBubble({
     />
   );
 }
-
-ButtonIconBubble.propTypes = buttonIconPropTypes;
 
 ButtonIconBubble.defaultProps = buttonIconDefaultProps;
 

--- a/lib/src/modules/Button/ButtonIcon/ButtonIconDanger.tsx
+++ b/lib/src/modules/Button/ButtonIcon/ButtonIconDanger.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import cx from "classnames";
 import { Icon } from "lib";
 import { ButtonBase } from "../ButtonBase";
-import {
-  sizes,
-  getSizeClasses,
-  buttonIconPropTypes,
-  buttonIconDefaultProps,
-} from "../common";
+import { sizes, getSizeClasses, buttonIconDefaultProps } from "../common";
 
 export function ButtonIconDanger({
   className,
@@ -45,7 +40,5 @@ export function ButtonIconDanger({
 }
 
 ButtonIconDanger.sizes = sizes;
-
-ButtonIconDanger.propTypes = buttonIconPropTypes;
 
 ButtonIconDanger.defaultProps = buttonIconDefaultProps;

--- a/lib/src/modules/Button/ButtonIcon/ButtonIconWhite.tsx
+++ b/lib/src/modules/Button/ButtonIcon/ButtonIconWhite.tsx
@@ -3,12 +3,7 @@ import { bool } from "prop-types";
 import cx from "classnames";
 import { Icon } from "lib";
 import { ButtonBase } from "../ButtonBase";
-import {
-  sizes,
-  getSizeClasses,
-  buttonIconPropTypes,
-  buttonIconDefaultProps,
-} from "../common";
+import { sizes, getSizeClasses, buttonIconDefaultProps } from "../common";
 
 export function ButtonIconWhite({
   className,
@@ -42,11 +37,6 @@ export function ButtonIconWhite({
 }
 
 ButtonIconWhite.sizes = sizes;
-
-ButtonIconWhite.propTypes = {
-  ...buttonIconPropTypes,
-  enabled: bool,
-};
 
 ButtonIconWhite.defaultProps = {
   ...buttonIconDefaultProps,

--- a/lib/src/modules/Button/ButtonLink/ButtonLink.tsx
+++ b/lib/src/modules/Button/ButtonLink/ButtonLink.tsx
@@ -1,12 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-function ButtonLink({
-  children,
-  className,
-  buttonRef,
-  ...rest
-}: any) {
+function ButtonLink({ children, className, buttonRef, ...rest }: any) {
   return (
     <button
       type="button"
@@ -19,13 +13,8 @@ function ButtonLink({
   );
 }
 
-ButtonLink.propTypes = {
-  children: node.isRequired,
-  className: string
-};
-
 ButtonLink.defaultProps = {
-  className: ''
+  className: "",
 };
 
 export { ButtonLink };

--- a/lib/src/modules/Button/ButtonPrimary/ButtonPrimary.tsx
+++ b/lib/src/modules/Button/ButtonPrimary/ButtonPrimary.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import cx from 'classnames';
-import { ButtonBase } from '../ButtonBase';
-import { propTypes, defaultProps, sizes } from '../common';
+import React from "react";
+import cx from "classnames";
+import { ButtonBase } from "../ButtonBase";
+import { ButtonTypes, defaultProps, sizes } from "../common";
 
 function ButtonPrimary({
   children,
@@ -9,15 +9,15 @@ function ButtonPrimary({
   disabled,
   connectedRight,
   ...rest
-}: any) {
-  const classes = cx('button-primary', className, {
-    'button-primary-connected-right': connectedRight
+}: ButtonTypes) {
+  const classes = cx("button-primary", className, {
+    "button-primary-connected-right": connectedRight,
   });
 
   return (
     <ButtonBase
       className={classes}
-      loaderTypes={['white']}
+      loaderTypes={["white"]}
       disabled={disabled}
       connectedRight={connectedRight}
       {...rest}
@@ -26,8 +26,6 @@ function ButtonPrimary({
     </ButtonBase>
   );
 }
-
-ButtonPrimary.propTypes = propTypes;
 
 ButtonPrimary.defaultProps = defaultProps;
 

--- a/lib/src/modules/Button/ButtonPrimary/ButtonPrimaryDanger.tsx
+++ b/lib/src/modules/Button/ButtonPrimary/ButtonPrimaryDanger.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import cx from 'classnames';
-import { ButtonBase } from '../ButtonBase';
-import { propTypes, defaultProps, sizes } from '../common';
+import React from "react";
+import cx from "classnames";
+import { ButtonBase } from "../ButtonBase";
+import { ButtonTypes, defaultProps, sizes } from "../common";
 
 function ButtonPrimaryDanger({
   children,
@@ -9,21 +9,21 @@ function ButtonPrimaryDanger({
   disabled,
   connectedRight,
   ...rest
-}: any) {
+}: ButtonTypes) {
   const disabledClasses = cx(
-    'text-neutral-primary bg-neutral-95 border-neutral-95',
+    "text-neutral-primary bg-neutral-95 border-neutral-95",
     {
-      'border-r-neutral-90': connectedRight
+      "border-r-neutral-90": connectedRight,
     }
   );
 
   const nonDisabledClasses = cx(
-    'text-white bg-red-primary border-red-primary',
-    'hover:bg-red-60',
-    'active:bg-red-40 active:border-red-30 active:shadow-none',
-    'focus:border-white focus:shadow-button-primary-danger-focus relative focus:z-50',
+    "text-white bg-red-primary border-red-primary",
+    "hover:bg-red-60",
+    "active:bg-red-40 active:border-red-30 active:shadow-none",
+    "focus:border-white focus:shadow-button-primary-danger-focus relative focus:z-50",
     {
-      'border-r-red-40': connectedRight
+      "border-r-red-40": connectedRight,
     }
   );
 
@@ -35,7 +35,7 @@ function ButtonPrimaryDanger({
   return (
     <ButtonBase
       className={classes}
-      loaderTypes={['white']}
+      loaderTypes={["white"]}
       disabled={disabled}
       connectedRight={connectedRight}
       {...rest}
@@ -44,8 +44,6 @@ function ButtonPrimaryDanger({
     </ButtonBase>
   );
 }
-
-ButtonPrimaryDanger.propTypes = propTypes;
 
 ButtonPrimaryDanger.defaultProps = defaultProps;
 

--- a/lib/src/modules/Button/ButtonSecondary/ButtonSecondary.tsx
+++ b/lib/src/modules/Button/ButtonSecondary/ButtonSecondary.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import cx from 'classnames';
-import { ButtonBase } from '../ButtonBase';
-import { propTypes, defaultProps, sizes } from '../common';
+import React from "react";
+import cx from "classnames";
+import { ButtonBase } from "../ButtonBase";
+import { defaultProps, sizes } from "../common";
 
 function ButtonSecondary({
   children,
@@ -10,8 +10,8 @@ function ButtonSecondary({
   active,
   ...rest
 }: any) {
-  const classes = cx('button-secondary inherit-color-icon', className, {
-    'button-secondary-active': active
+  const classes = cx("button-secondary inherit-color-icon", className, {
+    "button-secondary-active": active,
   });
 
   return (
@@ -25,8 +25,6 @@ function ButtonSecondary({
     </ButtonBase>
   );
 }
-
-ButtonSecondary.propTypes = propTypes;
 
 ButtonSecondary.defaultProps = defaultProps;
 

--- a/lib/src/modules/Button/ButtonSecondary/ButtonSecondaryDanger.tsx
+++ b/lib/src/modules/Button/ButtonSecondary/ButtonSecondaryDanger.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import cx from 'classnames';
-import { ButtonBase } from '../ButtonBase';
-import { propTypes, defaultProps, sizes } from '../common';
+import React from "react";
+import cx from "classnames";
+import { ButtonBase } from "../ButtonBase";
+import { defaultProps, sizes } from "../common";
 
 export function ButtonSecondaryDanger({
   children,
@@ -9,18 +9,18 @@ export function ButtonSecondaryDanger({
   disabled,
   ...rest
 }: any) {
-  const disabledClasses = cx('bg-neutral-95 text-neutral-primary');
+  const disabledClasses = cx("bg-neutral-95 text-neutral-primary");
 
   const nonDisabledClasses = cx(
-    'bg-white text-red-primary',
-    'hover:bg-red-95 hover:border-red-primary',
-    'active:bg-red-90 active:shadow-none'
+    "bg-white text-red-primary",
+    "hover:bg-red-95 hover:border-red-primary",
+    "active:bg-red-90 active:shadow-none"
   );
 
   const classes = cx(
-    'inherit-color-icon',
-    'border-neutral-90',
-    'focus:border-red-primary focus:shadow-button-tertiary-danger-focus',
+    "inherit-color-icon",
+    "border-neutral-90",
+    "focus:border-red-primary focus:shadow-button-tertiary-danger-focus",
     disabled ? disabledClasses : nonDisabledClasses,
     className
   );
@@ -31,8 +31,6 @@ export function ButtonSecondaryDanger({
     </ButtonBase>
   );
 }
-
-ButtonSecondaryDanger.propTypes = propTypes;
 
 ButtonSecondaryDanger.defaultProps = defaultProps;
 

--- a/lib/src/modules/Button/ButtonSuccess/ButtonSuccess.tsx
+++ b/lib/src/modules/Button/ButtonSuccess/ButtonSuccess.tsx
@@ -1,20 +1,14 @@
-import * as React from 'react';
-import { ButtonBase } from '../ButtonBase';
-import { defaultProps, propTypes, sizes } from '../common';
+import * as React from "react";
+import { ButtonBase } from "../ButtonBase";
+import { defaultProps, sizes } from "../common";
 
-export function ButtonSuccess({
-  children,
-  className = '',
-  ...rest
-}: any) {
+export function ButtonSuccess({ children, className = "", ...rest }: any) {
   return (
     <ButtonBase className={`button-success ${className}`} {...rest}>
       {children}
     </ButtonBase>
   );
 }
-
-ButtonSuccess.propTypes = propTypes;
 
 ButtonSuccess.defaultProps = defaultProps;
 

--- a/lib/src/modules/Button/ButtonTertiary/ButtonTertiary.tsx
+++ b/lib/src/modules/Button/ButtonTertiary/ButtonTertiary.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { bool } from 'prop-types';
-import cx from 'classnames';
-import { ButtonBase } from '../ButtonBase';
-import { propTypes, defaultProps, sizes } from '../common';
+import React from "react";
+import { bool } from "prop-types";
+import cx from "classnames";
+import { ButtonBase } from "../ButtonBase";
+import { defaultProps, sizes } from "../common";
 
 function ButtonTertiary({
   children,
@@ -12,15 +12,15 @@ function ButtonTertiary({
   contained,
   ...rest
 }: any) {
-  const classes = cx('button-tertiary', className, {
-    'button-tertiary-active': active,
-    'button-tertiary-contained': contained
+  const classes = cx("button-tertiary", className, {
+    "button-tertiary-active": active,
+    "button-tertiary-contained": contained,
   });
 
   return (
     <ButtonBase
       className={classes}
-      loaderTypes={['neutral-20']}
+      loaderTypes={["neutral-20"]}
       disabled={disabled}
       {...rest}
     >
@@ -29,14 +29,9 @@ function ButtonTertiary({
   );
 }
 
-ButtonTertiary.propTypes = {
-  ...propTypes,
-  active: bool
-};
-
 ButtonTertiary.defaultProps = {
   ...defaultProps,
-  active: false
+  active: false,
 };
 
 ButtonTertiary.sizes = sizes;

--- a/lib/src/modules/Button/ButtonTertiary/ButtonTertiaryDanger.tsx
+++ b/lib/src/modules/Button/ButtonTertiary/ButtonTertiaryDanger.tsx
@@ -1,31 +1,26 @@
-import React from 'react';
-import cx from 'classnames';
-import { ButtonBase } from '../ButtonBase';
-import { propTypes, defaultProps, sizes } from '../common';
+import React from "react";
+import cx from "classnames";
+import { ButtonBase } from "../ButtonBase";
+import { defaultProps, sizes } from "../common";
 
-function ButtonTertiaryDanger({
-  children,
-  className,
-  disabled,
-  ...rest
-}: any) {
+function ButtonTertiaryDanger({ children, className, disabled, ...rest }: any) {
   const nonDisabledClasses = cx(
-    'bg-white border-white',
-    'text-red-primary',
-    'hover:bg-red-95 hover:border-red-95',
-    'active:border-red-90 active:bg-red-90 active:shadow-none',
-    'focus:border-red-primary focus:shadow-button-tertiary-danger-focus'
+    "bg-white border-white",
+    "text-red-primary",
+    "hover:bg-red-95 hover:border-red-95",
+    "active:border-red-90 active:bg-red-90 active:shadow-none",
+    "focus:border-red-primary focus:shadow-button-tertiary-danger-focus"
   );
 
   const classes = cx(className, {
-    'text-neutral-primary bg-neutral-95 border-neutral-95': disabled,
-    [nonDisabledClasses]: !disabled
+    "text-neutral-primary bg-neutral-95 border-neutral-95": disabled,
+    [nonDisabledClasses]: !disabled,
   });
 
   return (
     <ButtonBase
       className={classes}
-      loaderTypes={['danger']}
+      loaderTypes={["danger"]}
       disabled={disabled}
       {...rest}
     >
@@ -33,8 +28,6 @@ function ButtonTertiaryDanger({
     </ButtonBase>
   );
 }
-
-ButtonTertiaryDanger.propTypes = propTypes;
 
 ButtonTertiaryDanger.defaultProps = defaultProps;
 

--- a/lib/src/modules/Button/common.ts
+++ b/lib/src/modules/Button/common.ts
@@ -1,5 +1,4 @@
-import { string, node, bool, func, oneOfType } from 'prop-types';
-import { omit } from 'lodash';
+
 
 export const sizes = {
   lg: 'lg',
@@ -24,18 +23,14 @@ export const getSizeClasses = (size: any) => {
   return 'w-6 h-6';
 };
 
-export const propTypes = {
-  children: oneOfType([node, func]).isRequired,
-  className: string,
-  type: string,
-  loading: bool,
-  loaderRight: bool,
-  size: oneOfType([string, bool]),
-  disabled: bool,
-  connectedLeft: bool,
-  connectedRight: bool,
-  onClick: func
-};
+
+export interface ButtonTypes extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  loading?: boolean;
+  loaderRight?: boolean;
+  size?: string | boolean;
+  connectedLeft?: boolean;
+  connectedRight?: boolean;
+}
 
 export const defaultProps = {
   className: '',
@@ -49,12 +44,7 @@ export const defaultProps = {
   onClick: () => {}
 };
 
-export const buttonIconPropTypes = {
-  ...omit(propTypes, 'children'),
-  active: bool,
-  iconTitle: string,
-  name: string
-};
+
 export const buttonIconDefaultProps = {
   ...defaultProps,
   active: false,

--- a/lib/src/modules/Button/stories/ButtonAvatar/ButtonAvatar.stories.tsx
+++ b/lib/src/modules/Button/stories/ButtonAvatar/ButtonAvatar.stories.tsx
@@ -30,14 +30,12 @@ export function ButtonAvatar() {
           </ButtonStoryItem>
 
           <ButtonStoryItem title="Disabled">
-            {/* @ts-expect-error */}
             <ButtonAvatarComponent {...props} disabled>
               Button text
             </ButtonAvatarComponent>
           </ButtonStoryItem>
 
           <ButtonStoryItem title="Active">
-            {/* @ts-expect-error */}
             <ButtonAvatarComponent {...props} active>
               Button text
             </ButtonAvatarComponent>

--- a/lib/src/modules/Button/stories/ButtonIcon/ButtonIcon.stories.tsx
+++ b/lib/src/modules/Button/stories/ButtonIcon/ButtonIcon.stories.tsx
@@ -21,108 +21,107 @@ export default {
 };
 
 export function ButtonIcon() {
-  return <StoryItem
-    title="ButtonIconComponent"
-    description="The icon button component"
-  >
-    <div className="flex flex-wrap justify-around">
-      <ButtonStoryItem title="Base (LG)">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconComponent
-              name="book"
-              size={ButtonIconComponent.sizes.lg}
-              {...s}
-            />
-          </div>
-        ))}
-      </ButtonStoryItem>
-      <ButtonStoryItem title="Base (MD)">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconComponent
-              name="fullScreen"
-              size={ButtonIconComponent.sizes.md}
-              {...s}
-            />
-          </div>
-        ))}
-      </ButtonStoryItem>
+  return (
+    <StoryItem
+      title="ButtonIconComponent"
+      description="The icon button component"
+    >
+      <div className="flex flex-wrap justify-around">
+        <ButtonStoryItem title="Base (LG)">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconComponent
+                name="book"
+                size={ButtonIconComponent.sizes.lg}
+                {...s}
+              />
+            </div>
+          ))}
+        </ButtonStoryItem>
+        <ButtonStoryItem title="Base (MD)">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconComponent
+                name="fullScreen"
+                size={ButtonIconComponent.sizes.md}
+                {...s}
+              />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      <ButtonStoryItem title="Base (SM)">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconComponent
-              name="caption16"
-              size={ButtonIconComponent.sizes.sm}
-              {...s}
-            />
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Base (SM)">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconComponent
+                name="caption16"
+                size={ButtonIconComponent.sizes.sm}
+                {...s}
+              />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      <ButtonStoryItem title="Base (counter)">
-        {states.map((s) => (
-          <div className="h-16">
-            {/* @ts-expect-error */}
-            <ButtonIconComponent name="caption16" {...s}>
-              <Counter>9</Counter>
-            </ButtonIconComponent>
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Base (counter)">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconComponent name="caption16" {...s}>
+                <Counter>9</Counter>
+              </ButtonIconComponent>
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      <ButtonStoryItem title="Danger">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconDanger name="caption16" {...s} />
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Danger">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconDanger name="caption16" {...s} />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      <ButtonStoryItem title="Contained">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconContained name="caption16" {...s} />
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Contained">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconContained name="caption16" {...s} />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      <ButtonStoryItem title="Contained Danger">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconContainedDanger name="caption16" {...s} />
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Contained Danger">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconContainedDanger name="caption16" {...s} />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      <ButtonStoryItem title="Bubble">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconBubble name="newComment" {...s} />
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Bubble">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconBubble name="newComment" {...s} />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      {/* @ts-expect-error TS(2322): Type '{ children: Element[]; title: string; classN... Remove this comment to see the full error message */}
-      <ButtonStoryItem title="Dark" className="bg-neutral-20 text-white">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconDark name="infoSquare" {...s} />
-          </div>
-        ))}
-      </ButtonStoryItem>
+        <ButtonStoryItem title="Dark" className="bg-neutral-20 text-white">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconDark name="infoSquare" {...s} />
+            </div>
+          ))}
+        </ButtonStoryItem>
 
-      {/* @ts-expect-error TS(2322): Type '{ children: Element[]; title: string; classN... Remove this comment to see the full error message */}
-      <ButtonStoryItem title="White" className="bg-neutral-20 text-white">
-        {states.map((s) => (
-          <div className="h-16">
-            <ButtonIconWhite name="menuDotted" {...s} />
-          </div>
-        ))}
-      </ButtonStoryItem>
-    </div>
-  </StoryItem>
+        <ButtonStoryItem title="White" className="bg-neutral-20 text-white">
+          {states.map((s) => (
+            <div className="h-16">
+              <ButtonIconWhite name="menuDotted" {...s} />
+            </div>
+          ))}
+        </ButtonStoryItem>
+      </div>
+    </StoryItem>
+  );
 }
 
 ButtonIcon.parameters = {

--- a/lib/src/modules/Button/stories/ButtonLink/ButtonLink.stories.tsx
+++ b/lib/src/modules/Button/stories/ButtonLink/ButtonLink.stories.tsx
@@ -1,28 +1,29 @@
 /* eslint-disable no-console */
-import React from 'react';
+import React from "react";
 // @ts-expect-error TS(2307): Cannot find module 'stories/styleguide/StoryItem' ... Remove this comment to see the full error message
-import StoryItem from 'stories/styleguide/StoryItem';
-import { ButtonLink as ButtonLinkComponent } from '../../ButtonLink/ButtonLink';
+import StoryItem from "stories/styleguide/StoryItem";
+import { ButtonLink as ButtonLinkComponent } from "../../ButtonLink/ButtonLink";
 
 export default {
-  title: 'GUI/Buttons/Button Link',
-  component: ButtonLinkComponent
+  title: "GUI/Buttons/Button Link",
+  component: ButtonLinkComponent,
 };
 
 export function ButtonLink() {
-  return <StoryItem
-    title="ButtonLinkComponent"
-    description="The link button component"
-  >
-    <ButtonLinkComponent
-      // @ts-expect-error TS(2322): Type '{ children: string; onClick: () => void; }' ... Remove this comment to see the full error message
-      onClick={() => console.log('Yo. Why did you click me?')}
+  return (
+    <StoryItem
+      title="ButtonLinkComponent"
+      description="The link button component"
     >
-      Looks like a link, acts like a button!
-    </ButtonLinkComponent>
-  </StoryItem>
+      <ButtonLinkComponent
+        onClick={() => console.log("Yo. Why did you click me?")}
+      >
+        Looks like a link, acts like a button!
+      </ButtonLinkComponent>
+    </StoryItem>
+  );
 }
 
 ButtonLink.parameters = {
-  controls: { hideNoControlsWarning: true }
+  controls: { hideNoControlsWarning: true },
 };

--- a/lib/src/modules/Button/stories/ButtonStoryItem.tsx
+++ b/lib/src/modules/Button/stories/ButtonStoryItem.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { node, string } from 'prop-types';
+import React from "react";
 
-function ButtonStoryItem({
-  children,
-  title,
-  className
-}: any) {
+function ButtonStoryItem({ children, title, className }: any) {
   return (
     <div className={`flex flex-col items-center px-2 ${className}`}>
       <h4>{title}</h4>
@@ -14,8 +9,4 @@ function ButtonStoryItem({
   );
 }
 
-ButtonStoryItem.propTypes = {
-  children: node.isRequired,
-  title: string.isRequired
-};
 export { ButtonStoryItem };

--- a/lib/src/modules/controls/Control.tsx
+++ b/lib/src/modules/controls/Control.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { bool, func, string } from "prop-types";
 import cx from "classnames";
 import { ButtonIconContained, ButtonIconContainedDanger } from "lib";
 
@@ -29,12 +28,6 @@ function Control({
     </div>
   );
 }
-
-Control.propTypes = {
-  onClick: func.isRequired,
-  iconName: string.isRequired,
-  danger: bool,
-};
 
 Control.defaultProps = {
   danger: false,

--- a/lib/src/modules/dateSet/DateSetTimeDropdown.tsx
+++ b/lib/src/modules/dateSet/DateSetTimeDropdown.tsx
@@ -44,7 +44,6 @@ export function DateSetTimeDropdown({ onTimeSelect, selectedTime }: any) {
                 onClick={toggleShowContent}
                 size={ButtonSecondary.sizes.sm}
                 className="ml-2"
-                // @ts-expect-error
                 contained
                 title="Select a time"
               >

--- a/lib/src/modules/inventoryItem/InventoryItem.stories.tsx
+++ b/lib/src/modules/inventoryItem/InventoryItem.stories.tsx
@@ -34,7 +34,6 @@ export function InventoryItem(args: any) {
                 iconName="text"
                 isPreviewActive={isDragging}
                 tooltipClassName="inline-block"
-                // @ts-expect-error
                 disabled={args.disabled}
               />
             </div>

--- a/lib/src/modules/inventoryItem/InventoryItem.tsx
+++ b/lib/src/modules/inventoryItem/InventoryItem.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import cx from "classnames";
-import { bool, string } from "prop-types";
 import { ButtonIconContained, TooltipWrapper } from "lib";
 
 export function InventoryItem({
@@ -39,17 +38,6 @@ export function InventoryItem({
     </TooltipWrapper>
   );
 }
-
-InventoryItem.propTypes = {
-  isPreviewActive: bool,
-  isPreview: bool,
-  iconName: string.isRequired,
-  tooltipClassName: string,
-  tooltipText: string,
-  className: string,
-  tooltipPlacement: string,
-  id: string,
-};
 
 InventoryItem.defaultProps = {
   isPreviewActive: false,

--- a/lib/src/modules/loader/Loader.stories.tsx
+++ b/lib/src/modules/loader/Loader.stories.tsx
@@ -11,17 +11,14 @@ export default {
 export function Loader() {
   return (
     <StoryItem title="LoaderComponent">
-        <div className="grid tw grid-cols-5 col-gap-4">
-          {/* @ts-expect-error */}
-          <LoaderComponent size="sm" />
-          {/* @ts-expect-error */}
-          <LoaderComponent size="md" />
-          {/* @ts-expect-error */}
-          <LoaderComponent size="lrg" />
-          <LoaderComponent progress="25%" />
-          <LoaderComponent heading="Processing" progress="100%" />
-        </div>
-      </StoryItem>
+      <div className="grid tw grid-cols-5 col-gap-4">
+        <LoaderComponent size="sm" />
+        <LoaderComponent size="md" />
+        <LoaderComponent size="lrg" />
+        <LoaderComponent progress="25%" />
+        <LoaderComponent heading="Processing" progress="100%" />
+      </div>
+    </StoryItem>
   );
 }
 

--- a/lib/src/modules/loader/Loader.tsx
+++ b/lib/src/modules/loader/Loader.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { string } from "prop-types";
 import cx from "classnames";
 import { Icon } from "lib";
 
@@ -27,11 +26,6 @@ function Loader({ heading, progress, size, className }: any) {
     </div>
   );
 }
-
-Loader.propTypes = {
-  heading: string,
-  progress: string,
-};
 
 Loader.defaultProps = {
   heading: null,

--- a/lib/src/modules/meta/MetaText.tsx
+++ b/lib/src/modules/meta/MetaText.tsx
@@ -1,25 +1,16 @@
-import React from 'react';
-import cx from 'classnames';
-import { bool } from 'prop-types';
+import React from "react";
+import cx from "classnames";
 
-function MetaText({
-  children,
-  className,
-  truncate
-}: any) {
-  const classNames = cx('meta-text text-neutral-primary text-sm', className, {
-    truncate
+function MetaText({ children, className, truncate }: any) {
+  const classNames = cx("meta-text text-neutral-primary text-sm", className, {
+    truncate,
   });
 
   return <div className={classNames}>{children}</div>;
 }
 
-MetaText.propTypes = {
-  truncate: bool
-};
-
 MetaText.defaultProps = {
-  truncate: true
+  truncate: true,
 };
 
 export { MetaText };

--- a/lib/src/modules/navigationItems/NavigationItems.tsx
+++ b/lib/src/modules/navigationItems/NavigationItems.tsx
@@ -1,15 +1,13 @@
-import React from 'react';
-import { func, node, string } from 'prop-types';
-import { NavigationProvider } from './NavigationProvider';
+import React from "react";
+import { NavigationProvider } from "./NavigationProvider";
 
 export function NavigationItems({
   children,
   onNav,
   defaultTabId,
-  srLabel
+  srLabel,
 }: any) {
   return (
-    // @ts-expect-error TS(2322): Type '{ children: Element; onNav: any; defaultTabI... Remove this comment to see the full error message
     <NavigationProvider onNav={onNav} defaultTabId={defaultTabId}>
       <nav className="navigation--items" aria-label={srLabel}>
         <ul role="menubar" aria-label={srLabel}>
@@ -20,13 +18,6 @@ export function NavigationItems({
   );
 }
 
-NavigationItems.propTypes = {
-  children: node.isRequired,
-  onNav: func,
-  defaultTabId: string.isRequired,
-  srLabel: string.isRequired
-};
-
 NavigationItems.defaultProps = {
-  onNav: () => {}
+  onNav: () => {},
 };

--- a/lib/src/modules/navigationItems/NavigationProvider.tsx
+++ b/lib/src/modules/navigationItems/NavigationProvider.tsx
@@ -1,13 +1,8 @@
-import React, { createContext, useState, useEffect } from 'react';
-import { node } from 'prop-types';
+import React, { createContext, useState, useEffect } from "react";
 
 const NavigationContext = createContext({});
 
-function NavigationProvider({
-  children,
-  onNav,
-  defaultTabId
-}: any) {
+function NavigationProvider({ children, onNav, defaultTabId }: any) {
   const [activeTabId, setActiveTabId] = useState(defaultTabId);
   const sharedState = { onNav, activeTabId, setActiveTabId };
 
@@ -21,10 +16,6 @@ function NavigationProvider({
     </NavigationContext.Provider>
   );
 }
-
-NavigationProvider.propTypes = {
-  children: node.isRequired
-};
 
 NavigationProvider.defaultProps = {};
 

--- a/lib/src/modules/preview/PreviewImage.tsx
+++ b/lib/src/modules/preview/PreviewImage.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { bool, node, string } from "prop-types";
 import { useImage } from "react-image";
 import cx from "classnames";
 // @ts-expect-error TS(2307): Cannot find module 'modules/loader/Loader' or its ... Remove this comment to see the full error message
@@ -69,15 +68,6 @@ function PreviewImage({
     </div>
   );
 }
-
-PreviewImage.propTypes = {
-  showLoader: bool,
-  fallback: node,
-  loader: node,
-  src: string.isRequired,
-  altText: string.isRequired,
-  title: string.isRequired,
-};
 
 PreviewImage.defaultProps = {
   showLoader: false,

--- a/lib/src/modules/slider/Slider.stories.tsx
+++ b/lib/src/modules/slider/Slider.stories.tsx
@@ -1,30 +1,30 @@
-import React, { useState } from 'react';
+import React, { useState } from "react";
 // @ts-expect-error TS(2307): Cannot find module 'stories/styleguide/StoryItem' ... Remove this comment to see the full error message
-import StoryItem from 'stories/styleguide/StoryItem';
-import { Slider as SliderComponent } from './Slider';
+import StoryItem from "stories/styleguide/StoryItem";
+import { Slider as SliderComponent } from "./Slider";
 
 export default {
-  title: 'GUI/Form/Inputs/Slider',
-  component: SliderComponent
+  title: "GUI/Form/Inputs/Slider",
+  component: SliderComponent,
 };
 
 export function Slider() {
   const [value, setValue] = useState(50);
   return (
     <StoryItem
-        title="SliderComponent"
-        description="An input type='range' styled nicely. Takes a children prop to allow the value to be displayed depending on what the slider is controlling."
+      title="SliderComponent"
+      description="An input type='range' styled nicely. Takes a children prop to allow the value to be displayed depending on what the slider is controlling."
+    >
+      <SliderComponent
+        value={+value}
+        onChange={(e: any) => setValue(e.target.value)}
       >
-        <SliderComponent
-          value={+value}
-          onChange={e => setValue(e.target.value)}
-        >
-          <p>{value}</p>
-        </SliderComponent>
-      </StoryItem>
+        <p>{value}</p>
+      </SliderComponent>
+    </StoryItem>
   );
 }
 
 Slider.parameters = {
-  controls: { hideNoControlsWarning: true }
+  controls: { hideNoControlsWarning: true },
 };

--- a/lib/src/modules/slider/Slider.tsx
+++ b/lib/src/modules/slider/Slider.tsx
@@ -1,5 +1,4 @@
-import React, { Fragment } from 'react';
-import { string, number, func, node } from 'prop-types';
+import React, { Fragment } from "react";
 
 export function Slider({
   id,
@@ -10,7 +9,7 @@ export function Slider({
   step,
   value,
   onChange,
-  children
+  children,
 }: any) {
   const valueAsPercent = (((value - min) * 100) / (max - min)).toFixed(0);
   return (
@@ -28,31 +27,19 @@ export function Slider({
         value={value}
         onChange={onChange}
         // @ts-expect-error TS(2322): Type '{ '--val': string; }' is not assignable to t... Remove this comment to see the full error message
-        style={{ '--val': valueAsPercent }}
+        style={{ "--val": valueAsPercent }}
       />
       {children}
     </>
   );
 }
 
-Slider.propTypes = {
-  id: string,
-  labelText: string,
-  labelClass: string,
-  min: number,
-  max: number,
-  step: number,
-  value: number.isRequired,
-  onChange: func.isRequired,
-  children: node
-};
-
 Slider.defaultProps = {
-  id: 'input-slider',
-  labelText: 'Slider',
-  labelClass: '',
+  id: "input-slider",
+  labelText: "Slider",
+  labelClass: "",
   min: 1,
   max: 100,
   step: 1,
-  children: null
+  children: null,
 };

--- a/lib/src/prefabs/assigneeDropdown/AssigneeDropdown.tsx
+++ b/lib/src/prefabs/assigneeDropdown/AssigneeDropdown.tsx
@@ -48,7 +48,6 @@ export function AssigneeDropdown({
                   active={showContent}
                   size={ButtonIcon.sizes.sm}
                   onClick={toggleShowContent}
-                  // @ts-expect-error
                   title="Change assignees"
                 />
               </TooltipWrapper>

--- a/lib/src/prefabs/dueDateDropdown/DueDateDropdown.tsx
+++ b/lib/src/prefabs/dueDateDropdown/DueDateDropdown.tsx
@@ -50,7 +50,6 @@ export function DueDateDropdown({
                   active={showContent}
                   size={ButtonIcon.sizes.sm}
                   onClick={toggleShowContent}
-                  // @ts-expect-error
                   title="Set a due date"
                 />
               </TooltipWrapper>

--- a/lib/src/prefabs/files/fileCard/FileCard.stories.tsx
+++ b/lib/src/prefabs/files/fileCard/FileCard.stories.tsx
@@ -51,7 +51,6 @@ export function FileCard(args: any) {
 
   function Preview({ children, loader }: any) {
     return (
-      // @ts-expect-error Type '{ children: any; src: string; altText: string; title: string; loader: any; showLoader: any; }' is not assignable to type 'IntrinsicAttributes
       <PreviewImage
         src={previewSrc}
         altText="preview image"
@@ -122,9 +121,7 @@ export function FileCard(args: any) {
         description="A card component which utilises the thumbnail size to display a file at a reduced size."
       >
         <FileCardComponent
-          // @ts-expect-error
           size="thumbnail"
-          // @ts-expect-error
           preview={<Preview loader={<Loader size="sm" />} />}
         />
       </StoryItem>
@@ -134,9 +131,7 @@ export function FileCard(args: any) {
         description="A card component which represents a loading file."
       >
         <div className="w-32 h-32">
-          {/* @ts-expect-error */}
           <FileCardComponent className="h-full" innerClassName="h-full">
-            {/* @ts-expect-error */}
             <Loader size="sm" className="h-full" />
           </FileCardComponent>
         </div>

--- a/lib/src/prefabs/files/fileCard/FileCard.tsx
+++ b/lib/src/prefabs/files/fileCard/FileCard.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { bool, node } from "prop-types";
 import cx from "classnames";
 import { Card } from "lib";
 
@@ -34,13 +33,6 @@ function FileCard({
     </Card>
   );
 }
-
-FileCard.propTypes = {
-  meta: node,
-  controls: node,
-  insetMeta: bool,
-  preview: node,
-};
 
 FileCard.defaultProps = {
   insetMeta: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "@testing-library/react": "^14.0.0",
         "@types/faker": "^6.6.9",
         "@types/jest": "^29.5.2",
+        "@types/react": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.60.1",
         "@vitejs/plugin-react": "^4.0.4",
@@ -11744,9 +11745,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "18.2.21",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
-      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "version": "18.2.22",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.22.tgz",
+      "integrity": "sha512-60fLTOLqzarLED2O3UQImc/lsNRgG0jE/a1mPW9KjMemY0LMITWEsbS4VvZ4p6rorEHd5YKxxmMKSDK505GHpA==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/faker": "^6.6.9",
     "@types/jest": "^29.5.2",
+    "@types/react": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.60.1",
     "@vitejs/plugin-react": "^4.0.4",

--- a/stories/components/Breadcrumb.stories.tsx
+++ b/stories/components/Breadcrumb.stories.tsx
@@ -6,75 +6,74 @@ export default {
   title: "Legacy/Breadcrumb",
 };
 
-export const Breadcrumb = () => (
-  <div>
-    <StoryItem title="BreadcrumbComponent">
-      <BreadcrumbComponent>
-        <BreadcrumbComponent.Item>
-          <div className="text-overflow-ellipsis" title="Energy Co. Redesign">
-            Energy Co. Redesign
-          </div>
-        </BreadcrumbComponent.Item>
-      </BreadcrumbComponent>
-    </StoryItem>
+export function Breadcrumb() {
+  return (
+    <div>
+      <StoryItem title="BreadcrumbComponent">
+        <BreadcrumbComponent>
+          <BreadcrumbComponent.Item>
+            <div className="text-overflow-ellipsis" title="Energy Co. Redesign">
+              Energy Co. Redesign
+            </div>
+          </BreadcrumbComponent.Item>
+        </BreadcrumbComponent>
+      </StoryItem>
 
-    <StoryItem title="BreadcrumbComponent">
-      <BreadcrumbComponent>
-        {/* @ts-expect-error */}
-        <BreadcrumbComponent.Item style={{ maxWidth: "20%" }}>
-          <div className="text-overflow-ellipsis" title="Energy Co. Redesign">
-            <a href="/">Energy Co. Redesign</a>
-          </div>
-        </BreadcrumbComponent.Item>
-        {/* @ts-expect-error */}
-        <BreadcrumbComponent.Item style={{ maxWidth: "20%" }}>
-          <div className="text-overflow-ellipsis" title="About">
-            <a href="/">About</a>
-          </div>
-        </BreadcrumbComponent.Item>
-        {/* @ts-expect-error */}
-        <BreadcrumbComponent.Item style={{ maxWidth: "50%" }}>
-          <div className="text-overflow-ellipsis" title="History">
-            History
-          </div>
-        </BreadcrumbComponent.Item>
-      </BreadcrumbComponent>
-    </StoryItem>
+      <StoryItem title="BreadcrumbComponent">
+        <BreadcrumbComponent>
+          <BreadcrumbComponent.Item style={{ maxWidth: "20%" }}>
+            <div className="text-overflow-ellipsis" title="Energy Co. Redesign">
+              <a href="/">Energy Co. Redesign</a>
+            </div>
+          </BreadcrumbComponent.Item>
+          <BreadcrumbComponent.Item style={{ maxWidth: "20%" }}>
+            <div className="text-overflow-ellipsis" title="About">
+              <a href="/">About</a>
+            </div>
+          </BreadcrumbComponent.Item>
+          <BreadcrumbComponent.Item style={{ maxWidth: "50%" }}>
+            <div className="text-overflow-ellipsis" title="History">
+              History
+            </div>
+          </BreadcrumbComponent.Item>
+        </BreadcrumbComponent>
+      </StoryItem>
 
-    <StoryItem title="BreadcrumbComponent">
-      <BreadcrumbComponent>
-        <BreadcrumbComponent.Item>
-          <Dropdown id="1">
-            <Dropdown.Trigger>...</Dropdown.Trigger>
-            <Dropdown.Content collapse>
-              <Dropdown.ActionGroup>
-                <a
-                  href="/"
-                  className="dropdown__action"
-                  title="Energy Co. Redesign"
-                >
-                  Energy Co. Redesign
-                </a>
-              </Dropdown.ActionGroup>
-            </Dropdown.Content>
-          </Dropdown>
-        </BreadcrumbComponent.Item>
-        <BreadcrumbComponent.Item>
-          <div className="text-overflow-ellipsis">
-            <a href="/" title="About">
-              About
-            </a>
-          </div>
-        </BreadcrumbComponent.Item>
-        <BreadcrumbComponent.Item>
-          <div className="text-overflow-ellipsis" title="History">
-            History
-          </div>
-        </BreadcrumbComponent.Item>
-      </BreadcrumbComponent>
-    </StoryItem>
-  </div>
-);
+      <StoryItem title="BreadcrumbComponent">
+        <BreadcrumbComponent>
+          <BreadcrumbComponent.Item>
+            <Dropdown id="1">
+              <Dropdown.Trigger>...</Dropdown.Trigger>
+              <Dropdown.Content collapse>
+                <Dropdown.ActionGroup>
+                  <a
+                    href="/"
+                    className="dropdown__action"
+                    title="Energy Co. Redesign"
+                  >
+                    Energy Co. Redesign
+                  </a>
+                </Dropdown.ActionGroup>
+              </Dropdown.Content>
+            </Dropdown>
+          </BreadcrumbComponent.Item>
+          <BreadcrumbComponent.Item>
+            <div className="text-overflow-ellipsis">
+              <a href="/" title="About">
+                About
+              </a>
+            </div>
+          </BreadcrumbComponent.Item>
+          <BreadcrumbComponent.Item>
+            <div className="text-overflow-ellipsis" title="History">
+              History
+            </div>
+          </BreadcrumbComponent.Item>
+        </BreadcrumbComponent>
+      </StoryItem>
+    </div>
+  );
+}
 
 Breadcrumb.parameters = {
   controls: { hideNoControlsWarning: true },

--- a/stories/components/CheckToggle.stories.tsx
+++ b/stories/components/CheckToggle.stories.tsx
@@ -1,14 +1,14 @@
-import React from 'react';
-import { action } from '@storybook/addon-actions';
-import CheckToggleComponent from '../../lib/CheckToggle';
-import StoryItem from '../styleguide/StoryItem';
+import React from "react";
+import { action } from "@storybook/addon-actions";
+import CheckToggleComponent from "../../lib/CheckToggle";
+import StoryItem from "../styleguide/StoryItem";
 
 export default {
-  title: 'Legacy/Check Toggle',
-  component: CheckToggleComponent
+  title: "Legacy/Check Toggle",
+  component: CheckToggleComponent,
 };
 
-export const CheckToggle = () => {
+export function CheckToggle() {
   return (
     <div>
       <StoryItem
@@ -50,13 +50,13 @@ export const CheckToggle = () => {
           id="four"
           labelRight={
             <>
-              Limit to{' '}
+              Limit to{" "}
               <input
                 type="number"
                 min={2}
-                onChange={action('input changed')}
+                onChange={action("input changed")}
                 className="w-1/4 rounded border border-solid border-neutral-90 py-quarter px-half shadow"
-              />{' '}
+              />{" "}
               fields
             </>
           }
@@ -67,8 +67,8 @@ export const CheckToggle = () => {
       </StoryItem>
     </div>
   );
-};
+}
 
 CheckToggle.parameters = {
-  controls: { hideNoControlsWarning: true }
+  controls: { hideNoControlsWarning: true },
 };

--- a/stories/components/Layout.stories.tsx
+++ b/stories/components/Layout.stories.tsx
@@ -10,7 +10,7 @@ export default {
   },
 };
 
-export const Layout = ({ isOpen }: any) => {
+export function Layout({ isOpen }: any) {
   return (
     <LayoutComponent>
       <style>{"#root { padding: 0 }"}</style>
@@ -29,14 +29,12 @@ export const Layout = ({ isOpen }: any) => {
           <LayoutComponent.Body className="bg-green-primary border-8 border-solid border-green-30">
             Body
           </LayoutComponent.Body>
-          {/* @ts-expect-error TS(2322): Type '{ children: string; className: string; anima... Remove this comment to see the full error message */}
           <LayoutComponent.Footer
             className="bg-yellow-primary h-10 border-8 border-solid border-yellow-30"
             animatableProperties={{ width: isOpen ? "75%" : "100%" }}
           >
             Footer
           </LayoutComponent.Footer>
-          {/* @ts-expect-error TS(2786): 'LayoutComponent.OverlaySidebar' cannot be used as... Remove this comment to see the full error message */}
           <LayoutComponent.OverlaySidebar className="top-0" isOpen={isOpen}>
             <Sidebar />
           </LayoutComponent.OverlaySidebar>
@@ -47,4 +45,4 @@ export const Layout = ({ isOpen }: any) => {
       </LayoutComponent.Section>
     </LayoutComponent>
   );
-};
+}

--- a/stories/components/List.stories.tsx
+++ b/stories/components/List.stories.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import StoryItem from "../styleguide/StoryItem";
 import {
   List as ListComponent,
   ListItem,
@@ -9,6 +8,7 @@ import {
   Icon,
   TooltipWrapper,
 } from "lib";
+import StoryItem from "../styleguide/StoryItem";
 
 const addNewItemButton = (
   size: any,
@@ -45,203 +45,215 @@ export default {
   title: "Legacy/List",
 };
 
-export const List = () => (
-  <div>
-    <StoryItem
-      title="List"
-      description="A list has a header with a title and action & children."
-    >
-      <ListComponent
-        title="Project Name"
-        action={addNewItemButton("minor", "bottom", "id-1", "Add new item")}
+export function List() {
+  return (
+    <div>
+      <StoryItem
+        title="List"
+        description="A list has a header with a title and action & children."
       >
-        <ListItem>List item text</ListItem>
-        <ListItem
-          action={addNewItemButton("small", "bottom", "id-2", "Add entry item")}
-          isCurrent
+        <ListComponent
+          title="Project Name"
+          action={addNewItemButton("minor", "bottom", "id-1", "Add new item")}
         >
-          List item text
-          <ListComponent>
-            <ListItem>List item text</ListItem>
-            <ListItem>List item text</ListItem>
-          </ListComponent>
-        </ListItem>
-      </ListComponent>
-    </StoryItem>
+          <ListItem>List item text</ListItem>
+          <ListItem
+            // @ts-expect-error
+            action={addNewItemButton(
+              "small",
+              "bottom",
+              "id-2",
+              "Add entry item"
+            )}
+            isCurrent
+          >
+            List item text
+            <ListComponent>
+              <ListItem>List item text</ListItem>
+              <ListItem>List item text</ListItem>
+            </ListComponent>
+          </ListItem>
+        </ListComponent>
+      </StoryItem>
 
-    <StoryItem title="List (boarded)">
-      <ListComponent
-        title="Project Name"
-        action={addNewItemButton(
-          "minor",
-          "bottom",
-          "id-12312312",
-          "Add new item"
-        )}
-        bordered
-      >
-        <ListItem isCurrent>List item text</ListItem>
-        <ListItem>List item text</ListItem>
-      </ListComponent>
-    </StoryItem>
-
-    <StoryItem title="List: Full Example">
-      <ListComponent
-        title="Example Project Title"
-        action={addNewItemButton(
-          "minor-2",
-          "bottom",
-          "id-32365689",
-          "Add new item"
-        )}
-        borderedRight
-      >
-        <ListItem
+      <StoryItem title="List (boarded)">
+        <ListComponent
+          title="Project Name"
           action={addNewItemButton(
-            "small-2",
+            "minor",
             "bottom",
-            "id-121212",
-            "Add entry item"
+            "id-12312312",
+            "Add new item"
           )}
-          collapse
-          isCurrent
+          bordered
         >
-          <a href="/#">
+          {/* @ts-expect-error */}
+          <ListItem isCurrent>List item text</ListItem>
+          <ListItem>List item text</ListItem>
+        </ListComponent>
+      </StoryItem>
+
+      <StoryItem title="List: Full Example">
+        <ListComponent
+          title="Example Project Title"
+          action={addNewItemButton(
+            "minor-2",
+            "bottom",
+            "id-32365689",
+            "Add new item"
+          )}
+          borderedRight
+        >
+          <ListItem
+            // @ts-expect-error
+            action={addNewItemButton(
+              "small-2",
+              "bottom",
+              "id-121212",
+              "Add entry item"
+            )}
+            collapse
+            isCurrent
+          >
+            <a href="/#">
+              <ItemRow
+                // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; }' i... Remove this comment to see the full error message
+                indicator={statusWithTooltip(
+                  "green",
+                  "bottom",
+                  "id-896727",
+                  "Research"
+                )}
+              >
+                Item name 1
+              </ItemRow>
+            </a>
+
+            <ListComponent>
+              {/* @ts-expect-error */}
+              <ListItem collapse>
+                <a href="/#">
+                  <ItemRow
+                    // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; }' i... Remove this comment to see the full error message
+                    indicator={statusWithTooltip(
+                      "blue",
+                      "bottom",
+                      "id-12376887",
+                      "Review"
+                    )}
+                  >
+                    Item name 2
+                  </ItemRow>
+                </a>
+              </ListItem>
+              {/* @ts-expect-error */}
+              <ListItem collapse>
+                <a href="/#">
+                  <ItemRow
+                    // @ts-expect-error TS(2322): Type '{ children: Element; indicator: Element; }' ... Remove this comment to see the full error message
+                    indicator={statusWithTooltip(
+                      "orange",
+                      "bottom",
+                      "id-9356342",
+                      "Publish"
+                    )}
+                  >
+                    {overdueTitle("Item name 3", "id-78978984224")}
+                  </ItemRow>
+                </a>
+
+                <ListComponent>
+                  {/* @ts-expect-error */}
+                  <ListItem collapse>
+                    <a href="/#">
+                      <ItemRow
+                        // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; }' i... Remove this comment to see the full error message
+                        indicator={statusWithTooltip(
+                          "blue",
+                          "bottom",
+                          "id-7858757",
+                          "Review"
+                        )}
+                      >
+                        Item name 4
+                      </ItemRow>
+                    </a>
+                  </ListItem>
+                  {/* @ts-expect-error */}
+                  <ListItem collapse>
+                    <a href="/#">
+                      <ItemRow
+                        // @ts-expect-error TS(2322): Type '{ children: Element; indicator: Element; }' ... Remove this comment to see the full error message
+                        indicator={statusWithTooltip(
+                          "orange",
+                          "bottom",
+                          "id-4444234",
+                          "Publish"
+                        )}
+                      >
+                        {overdueTitle("Item name 5", "id-24288448")}
+                      </ItemRow>
+                    </a>
+                  </ListItem>
+                </ListComponent>
+              </ListItem>
+            </ListComponent>
+          </ListItem>
+        </ListComponent>
+      </StoryItem>
+
+      <StoryItem title="Bordered List: Full Example">
+        <ListComponent
+          title="Project Name"
+          action={addNewItemButton(
+            "minor",
+            "bottom",
+            "id-12312312",
+            "Add new item"
+          )}
+          bordered
+          borderedLeft
+        >
+          {/* @ts-expect-error */}
+          <ListItem isCurrent>
             <ItemRow
-              // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; }' i... Remove this comment to see the full error message
-              indicator={statusWithTooltip(
-                "green",
-                "bottom",
-                "id-896727",
-                "Research"
-              )}
+              // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; stac... Remove this comment to see the full error message
+              indicator={
+                <StatusIndicator
+                  label="Approved"
+                  color="green"
+                  preText="Status:"
+                  small
+                  softLabel
+                />
+              }
+              stacked
             >
-              Item name 1
+              1st August 2018, 10:32am
             </ItemRow>
-          </a>
-
-          <ListComponent>
-            <ListItem collapse>
-              <a href="/#">
-                <ItemRow
-                  // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; }' i... Remove this comment to see the full error message
-                  indicator={statusWithTooltip(
-                    "blue",
-                    "bottom",
-                    "id-12376887",
-                    "Review"
-                  )}
-                >
-                  Item name 2
-                </ItemRow>
-              </a>
-            </ListItem>
-
-            <ListItem collapse>
-              <a href="/#">
-                <ItemRow
-                  // @ts-expect-error TS(2322): Type '{ children: Element; indicator: Element; }' ... Remove this comment to see the full error message
-                  indicator={statusWithTooltip(
-                    "orange",
-                    "bottom",
-                    "id-9356342",
-                    "Publish"
-                  )}
-                >
-                  {overdueTitle("Item name 3", "id-78978984224")}
-                </ItemRow>
-              </a>
-
-              <ListComponent>
-                <ListItem collapse>
-                  <a href="/#">
-                    <ItemRow
-                      // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; }' i... Remove this comment to see the full error message
-                      indicator={statusWithTooltip(
-                        "blue",
-                        "bottom",
-                        "id-7858757",
-                        "Review"
-                      )}
-                    >
-                      Item name 4
-                    </ItemRow>
-                  </a>
-                </ListItem>
-
-                <ListItem collapse>
-                  <a href="/#">
-                    <ItemRow
-                      // @ts-expect-error TS(2322): Type '{ children: Element; indicator: Element; }' ... Remove this comment to see the full error message
-                      indicator={statusWithTooltip(
-                        "orange",
-                        "bottom",
-                        "id-4444234",
-                        "Publish"
-                      )}
-                    >
-                      {overdueTitle("Item name 5", "id-24288448")}
-                    </ItemRow>
-                  </a>
-                </ListItem>
-              </ListComponent>
-            </ListItem>
-          </ListComponent>
-        </ListItem>
-      </ListComponent>
-    </StoryItem>
-
-    <StoryItem title="Bordered List: Full Example">
-      <ListComponent
-        title="Project Name"
-        action={addNewItemButton(
-          "minor",
-          "bottom",
-          "id-12312312",
-          "Add new item"
-        )}
-        bordered
-        borderedLeft
-      >
-        <ListItem isCurrent>
-          <ItemRow
-            // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; stac... Remove this comment to see the full error message
-            indicator={
-              <StatusIndicator
-                label="Approved"
-                color="green"
-                preText="Status:"
-                small
-                softLabel
-              />
-            }
-            stacked
-          >
-            1st August 2018, 10:32am
-          </ItemRow>
-        </ListItem>
-        <ListItem>
-          <ItemRow
-            // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; stac... Remove this comment to see the full error message
-            indicator={
-              <StatusIndicator
-                label="Approved"
-                color="green"
-                preText="Status:"
-                small
-                softLabel
-              />
-            }
-            stacked
-          >
-            1st August 2018, 10:32am
-          </ItemRow>
-        </ListItem>
-      </ListComponent>
-    </StoryItem>
-  </div>
-);
-
+          </ListItem>
+          <ListItem>
+            <ItemRow
+              // @ts-expect-error TS(2322): Type '{ children: string; indicator: Element; stac... Remove this comment to see the full error message
+              indicator={
+                <StatusIndicator
+                  label="Approved"
+                  color="green"
+                  preText="Status:"
+                  small
+                  softLabel
+                />
+              }
+              stacked
+            >
+              1st August 2018, 10:32am
+            </ItemRow>
+          </ListItem>
+        </ListComponent>
+      </StoryItem>
+    </div>
+  );
+}
 List.parameters = {
   controls: { hideNoControlsWarning: true },
 };

--- a/stories/components/Modal.stories.tsx
+++ b/stories/components/Modal.stories.tsx
@@ -31,7 +31,7 @@ export default {
 
 const ModalTrigger = withModalTrigger({ children: "Show Modal" });
 
-const StatefulFormModal = (props: any) => {
+function StatefulFormModal(props: any) {
   const [formIsSubmitting, setFormIsSubmitting] = useState(false);
 
   const submitHandler = (e: any) => {
@@ -51,634 +51,635 @@ const StatefulFormModal = (props: any) => {
       submitHandler={submitHandler}
     />
   );
-};
+}
 
-export const Modals = () => (
-  <div>
-    <StoryItem
-      title="Full Modal"
-      description="A modal has a header, footer and a content section."
-    >
-      <ModalTrigger>
-        <Modal.Container>
-          <Modal.Header>Hello</Modal.Header>
-          <Modal.Body>
-            <Row>
-              <Col
-                className="modal__column-wrapper modal__column-wrapper--highlight"
-                xs={6}
-              >
-                <div className="modal__column">
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident
-                </div>
-              </Col>
-              <Col className="modal__column-wrapper" xs={6}>
-                <div className="modal__column">
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident
-                </div>
-              </Col>
-            </Row>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button types={["link"]} clickHandler={action("clickHandler")}>
-              Cancel
-            </Button>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Selective Modal"
-      description="A modal that shows content and not the header or footer. You can pick whatever sections you do or don't require."
-    >
-      <ModalTrigger>
-        <Modal.Container>
-          <Modal.Body className="has-columns">
-            <Row className="modal__row">
-              <Col
-                xs={12}
-                sm={6}
-                className="modal__column-wrapper modal__column-wrapper--highlight"
-              >
-                <div className="modal__column">
-                  <h2 className="modal__body-title">Lorem ipsum dolor</h2>
-                </div>
-              </Col>
-              <Col xs={12} sm={6} className="modal__column-wrapper">
-                <div className="modal__column">
-                  <p>
+export function Modals() {
+  return (
+    <div>
+      <StoryItem
+        title="Full Modal"
+        description="A modal has a header, footer and a content section."
+      >
+        <ModalTrigger>
+          <Modal.Container>
+            <Modal.Header>Hello</Modal.Header>
+            <Modal.Body>
+              <Row>
+                <Col
+                  className="modal__column-wrapper modal__column-wrapper--highlight"
+                  xs={6}
+                >
+                  <div className="modal__column">
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit,
                     sed do eiusmod tempor incididunt ut labore et dolore magna
-                    aliqua.
-                  </p>
-                  <div className="modal__illustration">
-                    <div
-                      style={{
-                        background: "grey",
-                        height: "100px",
-                        color: "white",
-                      }}
-                    >
-                      Illustration goes here
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident
+                  </div>
+                </Col>
+                <Col className="modal__column-wrapper" xs={6}>
+                  <div className="modal__column">
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+                    sed do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident
+                  </div>
+                </Col>
+              </Row>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button types={["link"]} clickHandler={action("clickHandler")}>
+                Cancel
+              </Button>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Selective Modal"
+        description="A modal that shows content and not the header or footer. You can pick whatever sections you do or don't require."
+      >
+        <ModalTrigger>
+          <Modal.Container>
+            <Modal.Body className="has-columns">
+              <Row className="modal__row">
+                <Col
+                  xs={12}
+                  sm={6}
+                  className="modal__column-wrapper modal__column-wrapper--highlight"
+                >
+                  <div className="modal__column">
+                    <h2 className="modal__body-title">Lorem ipsum dolor</h2>
+                  </div>
+                </Col>
+                <Col xs={12} sm={6} className="modal__column-wrapper">
+                  <div className="modal__column">
+                    <p>
+                      Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+                      sed do eiusmod tempor incididunt ut labore et dolore magna
+                      aliqua.
+                    </p>
+                    <div className="modal__illustration">
+                      <div
+                        style={{
+                          background: "grey",
+                          height: "100px",
+                          color: "white",
+                        }}
+                      >
+                        Illustration goes here
+                      </div>
                     </div>
                   </div>
-                </div>
-              </Col>
-            </Row>
-          </Modal.Body>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
+                </Col>
+              </Row>
+            </Modal.Body>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
 
-    <StoryItem
-      title="Cleared and input-confirm"
-      description="A modal that has the backgrounds/borders cleared and a slightly larger padding"
-    >
-      <ModalTrigger>
-        <Modal.Container className="modal--clear modal--input-confirm">
-          <Modal.Header>Confirm deletion</Modal.Header>
-          <Modal.Body>
-            File deletion is permanent and cannot be undone. Please confirm you
-            want to delete these files by typing ‘DELETE’ in the box below.
-            <FormInput
-              placeholder="Type ‘DELETE’ to confirm..."
-              className="block w-64 mt-3"
-              focusOnMount
-            />
-          </Modal.Body>
-          <Modal.Footer>
-            <ButtonTertiary
-              size={ButtonTertiary.sizes.md}
-              onClick={action("Cancel delete")}
-              className="mr-2"
-            >
-              Cancel
-            </ButtonTertiary>
-            <ButtonPrimaryDanger
-              size={ButtonPrimaryDanger.sizes.md}
-              onClick={action("Confirm delete")}
-              loading={false}
-            >
-              Delete
-            </ButtonPrimaryDanger>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Centered & Cleared"
-      description="A modal that has its content centered and the backgrounds/borders cleared."
-    >
-      <ModalTrigger>
-        <Modal.Container className="modal--center modal--clear" size="small">
-          <Modal.Header>Lorem ipsum dolor</Modal.Header>
-          <Modal.Body>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident
-          </Modal.Body>
-          <Modal.Footer>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Large"
-      description="Modals can be larger than normal width."
-    >
-      <ModalTrigger>
-        <Modal.Container size="large">
-          <Modal.Body>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident
-          </Modal.Body>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Extra Large"
-      description="Modals can be extra large width!"
-    >
-      <ModalTrigger>
-        <Modal.Container size="x-large">
-          <Modal.Body>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident
-          </Modal.Body>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem title="Full Screen" description="Modals can take up the screen">
-      <ModalTrigger>
-        <Modal.Container size="full-screen">
-          <Modal.Body>
-            Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
-            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-            aliquip ex ea commodo consequat. Duis aute irure dolor in
-            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-            pariatur. Excepteur sint occaecat cupidatat non proident
-          </Modal.Body>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Confirmation Modal"
-      description="A toggle component that can be used to toggle options on and off."
-    >
-      <ModalTrigger>
-        <ConfirmationModal
-          title="Are you sure?"
-          introText="Are you really sure?"
-          submitText="Hell yes"
-          cancelText="Meow no"
-          // @ts-expect-error
-          type="primary"
-          onHide={() => {}}
-          submitCallback={(e: any) => {
-            action(e);
-            e.preventDefault();
-          }}
-          footerContent={
-            <>
-              Changes will be made to <strong>2 items.</strong>
-            </>
-          }
-          highlight
-          overflowHalf
-        >
-          <StatusIndicator color="#93724f" label="Draft" row softLabel>
-            <DueDatePicker
-              applyDueDate={() => {}}
-              removeDueDate={() => {}}
-              autoPosition
-              row
-            >
-              20th Feb 2019
-            </DueDatePicker>
-          </StatusIndicator>
-          <StatusIndicator color="green" label="Publishing" row softLabel>
-            <DueDatePicker
-              applyDueDate={() => {}}
-              removeDueDate={() => {}}
-              autoPosition
-              row
-            >
-              20th Feb 2019
-            </DueDatePicker>
-          </StatusIndicator>
-          <StatusIndicator color="green" label="Publishing" row softLabel>
-            <DueDatePicker
-              applyDueDate={() => {}}
-              removeDueDate={() => {}}
-              autoPosition
-              row
-            >
-              20th Feb 2019
-            </DueDatePicker>
-          </StatusIndicator>
-          <StatusIndicator color="green" label="Publishing" row softLabel>
-            <DueDatePicker
-              applyDueDate={() => {}}
-              removeDueDate={() => {}}
-              autoPosition
-              row
-            >
-              20th Feb 2019
-            </DueDatePicker>
-          </StatusIndicator>
-        </ConfirmationModal>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Overflow Modal"
-      description="A modal which has content that overflows the screen."
-    >
-      <ModalTrigger>
-        <Modal.Container overflow>
-          <Modal.Header>Hello</Modal.Header>
-          <Modal.Body className="has-columns">
-            <Row>
-              <Col
-                className="modal__column-wrapper modal__column-wrapper--highlight"
-                xs={6}
+      <StoryItem
+        title="Cleared and input-confirm"
+        description="A modal that has the backgrounds/borders cleared and a slightly larger padding"
+      >
+        <ModalTrigger>
+          <Modal.Container className="modal--clear modal--input-confirm">
+            <Modal.Header>Confirm deletion</Modal.Header>
+            <Modal.Body>
+              File deletion is permanent and cannot be undone. Please confirm
+              you want to delete these files by typing ‘DELETE’ in the box
+              below.
+              <FormInput
+                placeholder="Type ‘DELETE’ to confirm..."
+                className="block w-64 mt-3"
+                focusOnMount
+              />
+            </Modal.Body>
+            <Modal.Footer>
+              <ButtonTertiary
+                size={ButtonTertiary.sizes.md}
+                onClick={action("Cancel delete")}
+                className="mr-2"
               >
-                <div className="modal__column">
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident Lorem ipsum dolor sit amet, consectetur
-                  adipisicing elit, sed do eiusmod tempor incididunt ut labore
-                  et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                  exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                  consequat. Duis aute irure dolor in reprehenderit in voluptate
-                  velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
-                  sint occaecat cupidatat non proident Lorem ipsum dolor sit
-                  amet, consectetur adipisicing elit, sed do eiusmod tempor
-                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-                  veniam, quis nostrud exercitation ullamco laboris nisi ut
-                  aliquip ex ea commodo consequat. Duis aute irure dolor in
-                  reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                  nulla pariatur. Excepteur sint occaecat cupidatat non proident
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident Lorem ipsum dolor sit amet, consectetur
-                  adipisicing elit, sed do eiusmod tempor incididunt ut labore
-                  et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud
-                  exercitation ullamco laboris nisi ut aliquip ex ea commodo
-                  consequat. Duis aute irure dolor in reprehenderit in voluptate
-                  velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
-                  sint occaecat cupidatat non proident Lorem ipsum dolor sit
-                  amet, consectetur adipisicing elit, sed do eiusmod tempor
-                  incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-                  veniam, quis nostrud exercitation ullamco laboris nisi ut
-                  aliquip ex ea commodo consequat. Duis aute irure dolor in
-                  reprehenderit in voluptate velit esse cillum dolore eu fugiat
-                  nulla pariatur. Excepteur sint occaecat cupidatat non proident
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident
-                </div>
-              </Col>
-              <Col className="modal__column-wrapper" xs={6}>
-                <div className="modal__column">
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident
-                </div>
-              </Col>
-            </Row>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button types={["link"]} clickHandler={action("clickHandler")}>
-              Cancel
-            </Button>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="FormModal"
-      description="A modal which can contain a form. It has a progress button to indicate progress while submitting"
-    >
-      <ModalTrigger>
-        <StatefulFormModal
-          title="FormModal example"
-          submitText="Submit"
-          cancelText="Cancel"
-          highlight
-        >
-          <Label htmlFor="form-modal-field-a">Field A</Label>
-          <Input id="form-modal-field-a" className="mb-3" />
-          <Label htmlFor="form-modal-field-b">Field B</Label>
-          <Input id="form-modal-field-b" />
-        </StatefulFormModal>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Media only modal"
-      description="A modal which is used for displaying larger formats of files such as images."
-    >
-      <ModalTrigger>
-        <Modal.Container collapse mediaOnly size="full-screen">
-          <Modal.Header />
-          <Modal.Body>
-            <ImageLoader
-              src="https://placekitten.com/g/500/500"
-              alt="A lovely pic!"
-              preLoadedStyles={{
-                width: "300px",
-                height: "300px",
-              }}
-              loadTransition
-            />
-          </Modal.Body>
-          <Modal.Footer>
-            <ButtonGroup>
-              <Button onClick={() => {}} types={["icon-only"]}>
-                <Icon name="download" />
-              </Button>
-              <Button onClick={() => {}} types={["icon-only"]}>
-                <Icon name="trash" />
-              </Button>
-            </ButtonGroup>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Modal Footer with Space Between Modifier"
-      description="Modal footer with the items set to be to be spaced out"
-    >
-      <ModalTrigger>
-        <Modal.Container>
-          <Modal.Header>Hello</Modal.Header>
-          <Modal.Body className="has-columns">
-            <Row>
-              <Col
-                className="modal__column-wrapper modal__column-wrapper--highlight"
-                xs={6}
+                Cancel
+              </ButtonTertiary>
+              <ButtonPrimaryDanger
+                size={ButtonPrimaryDanger.sizes.md}
+                onClick={action("Confirm delete")}
+                loading={false}
               >
-                <div className="modal__column">
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident
-                </div>
-              </Col>
-              <Col className="modal__column-wrapper" xs={6}>
-                <div className="modal__column">
-                  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                  laboris nisi ut aliquip ex ea commodo consequat. Duis aute
-                  irure dolor in reprehenderit in voluptate velit esse cillum
-                  dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-                  cupidatat non proident
-                </div>
-              </Col>
-            </Row>
-          </Modal.Body>
-          <Modal.Footer spaceBetween>
-            <Button types={["link"]} clickHandler={action("clickHandler")}>
-              Cancel
-            </Button>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
+                Delete
+              </ButtonPrimaryDanger>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
 
-    <StoryItem
-      title="Modal with ImageHeader"
-      description="Modal with ImageHeader to display an image."
-    >
-      <ModalTrigger>
-        <Modal.Container>
-          <Modal.ImageHeader
-            height={401}
-            imageUrl="https://metro.co.uk/wp-content/uploads/2017/07/187144066.jpg?quality=90&strip=all"
+      <StoryItem
+        title="Centered & Cleared"
+        description="A modal that has its content centered and the backgrounds/borders cleared."
+      >
+        <ModalTrigger>
+          <Modal.Container className="modal--center modal--clear" size="small">
+            <Modal.Header>Lorem ipsum dolor</Modal.Header>
+            <Modal.Body>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident
+            </Modal.Body>
+            <Modal.Footer>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Large"
+        description="Modals can be larger than normal width."
+      >
+        <ModalTrigger>
+          <Modal.Container size="large">
+            <Modal.Body>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident
+            </Modal.Body>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Extra Large"
+        description="Modals can be extra large width!"
+      >
+        <ModalTrigger>
+          <Modal.Container size="x-large">
+            <Modal.Body>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident
+            </Modal.Body>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Full Screen"
+        description="Modals can take up the screen"
+      >
+        <ModalTrigger>
+          <Modal.Container size="full-screen">
+            <Modal.Body>
+              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+              reprehenderit in voluptate velit esse cillum dolore eu fugiat
+              nulla pariatur. Excepteur sint occaecat cupidatat non proident
+            </Modal.Body>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Confirmation Modal"
+        description="A toggle component that can be used to toggle options on and off."
+      >
+        <ModalTrigger>
+          <ConfirmationModal
+            title="Are you sure?"
+            introText="Are you really sure?"
+            submitText="Hell yes"
+            cancelText="Meow no"
+            type="primary"
+            onHide={() => {}}
+            submitCallback={(e: any) => {
+              action(e);
+              e.preventDefault();
+            }}
+            footerContent={
+              <>
+                Changes will be made to <strong>2 items.</strong>
+              </>
+            }
+            highlight
+            overflowHalf
+          >
+            <StatusIndicator color="#93724f" label="Draft" row softLabel>
+              <DueDatePicker
+                applyDueDate={() => {}}
+                removeDueDate={() => {}}
+                autoPosition
+                row
+              >
+                20th Feb 2019
+              </DueDatePicker>
+            </StatusIndicator>
+            <StatusIndicator color="green" label="Publishing" row softLabel>
+              <DueDatePicker
+                applyDueDate={() => {}}
+                removeDueDate={() => {}}
+                autoPosition
+                row
+              >
+                20th Feb 2019
+              </DueDatePicker>
+            </StatusIndicator>
+            <StatusIndicator color="green" label="Publishing" row softLabel>
+              <DueDatePicker
+                applyDueDate={() => {}}
+                removeDueDate={() => {}}
+                autoPosition
+                row
+              >
+                20th Feb 2019
+              </DueDatePicker>
+            </StatusIndicator>
+            <StatusIndicator color="green" label="Publishing" row softLabel>
+              <DueDatePicker
+                applyDueDate={() => {}}
+                removeDueDate={() => {}}
+                autoPosition
+                row
+              >
+                20th Feb 2019
+              </DueDatePicker>
+            </StatusIndicator>
+          </ConfirmationModal>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Overflow Modal"
+        description="A modal which has content that overflows the screen."
+      >
+        <ModalTrigger>
+          <Modal.Container overflow>
+            <Modal.Header>Hello</Modal.Header>
+            <Modal.Body className="has-columns">
+              <Row>
+                <Col
+                  className="modal__column-wrapper modal__column-wrapper--highlight"
+                  xs={6}
+                >
+                  <div className="modal__column">
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+                    sed do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident Lorem ipsum dolor sit amet,
+                    consectetur adipisicing elit, sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua. Ut enim ad
+                    minim veniam, quis nostrud exercitation ullamco laboris nisi
+                    ut aliquip ex ea commodo consequat. Duis aute irure dolor in
+                    reprehenderit in voluptate velit esse cillum dolore eu
+                    fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+                    proident Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit, sed do eiusmod tempor incididunt ut labore et dolore
+                    magna aliqua. Ut enim ad minim veniam, quis nostrud
+                    exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Duis aute irure dolor in reprehenderit in
+                    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    Excepteur sint occaecat cupidatat non proident Lorem ipsum
+                    dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                    tempor incididunt ut labore et dolore magna aliqua. Ut enim
+                    ad minim veniam, quis nostrud exercitation ullamco laboris
+                    nisi ut aliquip ex ea commodo consequat. Duis aute irure
+                    dolor in reprehenderit in voluptate velit esse cillum dolore
+                    eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                    non proident Lorem ipsum dolor sit amet, consectetur
+                    adipisicing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua. Ut enim ad minim veniam, quis
+                    nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+                    commodo consequat. Duis aute irure dolor in reprehenderit in
+                    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    Excepteur sint occaecat cupidatat non proident Lorem ipsum
+                    dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+                    tempor incididunt ut labore et dolore magna aliqua. Ut enim
+                    ad minim veniam, quis nostrud exercitation ullamco laboris
+                    nisi ut aliquip ex ea commodo consequat. Duis aute irure
+                    dolor in reprehenderit in voluptate velit esse cillum dolore
+                    eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                    non proident Lorem ipsum dolor sit amet, consectetur
+                    adipisicing elit, sed do eiusmod tempor incididunt ut labore
+                    et dolore magna aliqua. Ut enim ad minim veniam, quis
+                    nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+                    commodo consequat. Duis aute irure dolor in reprehenderit in
+                    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+                    Excepteur sint occaecat cupidatat non proident
+                  </div>
+                </Col>
+                <Col className="modal__column-wrapper" xs={6}>
+                  <div className="modal__column">
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+                    sed do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident
+                  </div>
+                </Col>
+              </Row>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button types={["link"]} clickHandler={action("clickHandler")}>
+                Cancel
+              </Button>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="FormModal"
+        description="A modal which can contain a form. It has a progress button to indicate progress while submitting"
+      >
+        <ModalTrigger>
+          <StatefulFormModal
+            title="FormModal example"
+            submitText="Submit"
+            cancelText="Cancel"
+            highlight
+          >
+            <Label htmlFor="form-modal-field-a">Field A</Label>
+            <Input id="form-modal-field-a" className="mb-3" />
+            <Label htmlFor="form-modal-field-b">Field B</Label>
+            <Input id="form-modal-field-b" />
+          </StatefulFormModal>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Media only modal"
+        description="A modal which is used for displaying larger formats of files such as images."
+      >
+        <ModalTrigger>
+          <Modal.Container collapse mediaOnly size="full-screen">
+            <Modal.Header />
+            <Modal.Body>
+              <ImageLoader
+                // @ts-expect-error
+                src="https://placekitten.com/g/500/500"
+                alt="A lovely pic!"
+                preLoadedStyles={{
+                  width: "300px",
+                  height: "300px",
+                }}
+                loadTransition
+              />
+            </Modal.Body>
+            <Modal.Footer>
+              <ButtonGroup>
+                <Button onClick={() => {}} types={["icon-only"]}>
+                  <Icon name="download" />
+                </Button>
+                <Button onClick={() => {}} types={["icon-only"]}>
+                  <Icon name="trash" />
+                </Button>
+              </ButtonGroup>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Modal Footer with Space Between Modifier"
+        description="Modal footer with the items set to be to be spaced out"
+      >
+        <ModalTrigger>
+          <Modal.Container>
+            <Modal.Header>Hello</Modal.Header>
+            <Modal.Body className="has-columns">
+              <Row>
+                <Col
+                  className="modal__column-wrapper modal__column-wrapper--highlight"
+                  xs={6}
+                >
+                  <div className="modal__column">
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+                    sed do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident
+                  </div>
+                </Col>
+                <Col className="modal__column-wrapper" xs={6}>
+                  <div className="modal__column">
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit,
+                    sed do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+                    occaecat cupidatat non proident
+                  </div>
+                </Col>
+              </Row>
+            </Modal.Body>
+            <Modal.Footer spaceBetween>
+              <Button types={["link"]} clickHandler={action("clickHandler")}>
+                Cancel
+              </Button>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Modal with ImageHeader"
+        description="Modal with ImageHeader to display an image."
+      >
+        <ModalTrigger>
+          <Modal.Container>
+            <Modal.ImageHeader
+              height={401}
+              imageUrl="https://metro.co.uk/wp-content/uploads/2017/07/187144066.jpg?quality=90&strip=all"
+            />
+            <Modal.Body>Look at this lovely image ☝️</Modal.Body>
+            <Modal.Footer spaceBetween>
+              <Button types={["link"]} clickHandler={action("clickHandler")}>
+                Cancel
+              </Button>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+
+      <StoryItem
+        title="Modal with ModalHeaderNavigation"
+        description="Modal with tabs in the header."
+      >
+        <ModalTrigger>
+          <Modal.Container size="large">
+            <Modal.HeaderWithNavigation title="Title!">
+              <MenuItem
+                style={{ bottom: "-3px" }}
+                active
+                onClick={action("clickHandler")}
+              >
+                {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+                <div className="h-full w-full" role="menuitem" tabIndex={0}>
+                  Tab 1
+                </div>
+              </MenuItem>
+              <MenuItem
+                style={{ bottom: "-3px" }}
+                onClick={action("clickHandler")}
+              >
+                {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+                <div className="h-full w-full" role="menuitem" tabIndex={0}>
+                  Tab 2
+                </div>
+              </MenuItem>
+            </Modal.HeaderWithNavigation>
+            <Modal.Body>Here is some body️</Modal.Body>
+            <Modal.Footer spaceBetween>
+              <Button types={["link"]} clickHandler={action("clickHandler")}>
+                Cancel
+              </Button>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </Modal.Container>
+        </ModalTrigger>
+      </StoryItem>
+      <StoryItem
+        title="SelectionModal"
+        description="SelectionModal can be used with other Modal components to create a selection layout"
+      >
+        <ModalTrigger>
+          <SelectionModal size="large">
+            <Modal.Header useTitle={false}>
+              <h3 className="text-lg mt-2 mb-3">Import templates</h3>
+              <p className="m-0 leading-6">
+                Imported templates will be duplicated, meaning changes made to
+                the originals won’t be reflected here. Any components will also
+                be imported in the process.
+              </p>
+            </Modal.Header>
+            <SelectionModal.Body>
+              <SelectionModal.Column
+                isHighlight
+                className="w-3/6 flex-shrink-0 px-4 pb-8"
+              >
+                <SelectionModal.ColumnHeader className="mb-3">
+                  PROJECTS
+                </SelectionModal.ColumnHeader>
+                <SelectionModal.Category
+                  name="Project 1"
+                  subText="3 templates"
+                  isSelected
+                  counter={2}
+                  className="mb-2"
+                />
+                <SelectionModal.Category
+                  name="Project 2"
+                  subText="7 templates"
+                  isSelected={false}
+                  className="mb-2"
+                />
+                <SelectionModal.Category
+                  name="Project 3"
+                  subText="56 templates"
+                  isSelected={false}
+                  counter={10}
+                  className="mb-2"
+                />
+              </SelectionModal.Column>
+              <SelectionModal.Column className="px-1 pb-8">
+                <SelectionModal.ColumnHeader className="ml-2">
+                  TEMPLATES
+                </SelectionModal.ColumnHeader>
+                <Checkbox
+                  id="template 1"
+                  label="template 1"
+                  name="template 1"
+                  className="text-base"
+                />
+                <Checkbox
+                  id="template 2"
+                  label="template 2"
+                  name="template 2"
+                  className="text-base"
+                />
+                <Checkbox
+                  id="template 3"
+                  label="template 3"
+                  name="template 3"
+                  className="text-base"
+                />
+                <Checkbox
+                  id="template 4"
+                  label="template 4"
+                  name="template 4"
+                  className="text-base"
+                />
+              </SelectionModal.Column>
+            </SelectionModal.Body>
+            <Modal.Footer spaceBetween>
+              <Button types={["link"]} clickHandler={action("clickHandler")}>
+                Cancel
+              </Button>
+              <Button types={["primary"]} clickHandler={action("clickHandler")}>
+                Confirm
+              </Button>
+            </Modal.Footer>
+          </SelectionModal>
+        </ModalTrigger>
+      </StoryItem>
+      <StoryItem
+        title="InputConfirmationModal"
+        description="A modal to make sure you are really sure that you want to do something."
+      >
+        <ModalTrigger>
+          <InputConfirmationModal
+            introTitle="Delete templates"
+            confirmTitle="Confirm deletion"
+            introBody="This template is currently being used. Any items using this template will be converted to use a custom structure. Are you sure you want to continue?"
+            confirmBody="Template deletion is permanent and cannot be undone. Please confirm you want to delete this template by typing ‘DELETE’ in the box below."
+            onConfirm={() => {}}
           />
-          <Modal.Body>Look at this lovely image ☝️</Modal.Body>
-          <Modal.Footer spaceBetween>
-            <Button types={["link"]} clickHandler={action("clickHandler")}>
-              Cancel
-            </Button>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-
-    <StoryItem
-      title="Modal with ModalHeaderNavigation"
-      description="Modal with tabs in the header."
-    >
-      <ModalTrigger>
-        <Modal.Container size="large">
-          <Modal.HeaderWithNavigation title="Title!">
-            <MenuItem
-              style={{ bottom: "-3px" }}
-              active
-              onClick={action("clickHandler")}
-            >
-              {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-              <div className="h-full w-full" role="menuitem" tabIndex={0}>
-                Tab 1
-              </div>
-            </MenuItem>
-            <MenuItem
-              style={{ bottom: "-3px" }}
-              onClick={action("clickHandler")}
-            >
-              {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-              <div className="h-full w-full" role="menuitem" tabIndex={0}>
-                Tab 2
-              </div>
-            </MenuItem>
-          </Modal.HeaderWithNavigation>
-          <Modal.Body>Here is some body️</Modal.Body>
-          <Modal.Footer spaceBetween>
-            <Button types={["link"]} clickHandler={action("clickHandler")}>
-              Cancel
-            </Button>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </Modal.Container>
-      </ModalTrigger>
-    </StoryItem>
-    <StoryItem
-      title="SelectionModal"
-      description="SelectionModal can be used with other Modal components to create a selection layout"
-    >
-      <ModalTrigger>
-        {/* @ts-expect-error */}
-        <SelectionModal size="large">
-          {/* @ts-expect-error */}
-          <Modal.Header useTitle={false}>
-            <h3 className="text-lg mt-2 mb-3">Import templates</h3>
-            <p className="m-0 leading-6">
-              Imported templates will be duplicated, meaning changes made to the
-              originals won’t be reflected here. Any components will also be
-              imported in the process.
-            </p>
-          </Modal.Header>
-          <SelectionModal.Body>
-            <SelectionModal.Column
-              isHighlight
-              className="w-3/6 flex-shrink-0 px-4 pb-8"
-            >
-              <SelectionModal.ColumnHeader className="mb-3">
-                PROJECTS
-              </SelectionModal.ColumnHeader>
-              <SelectionModal.Category
-                name="Project 1"
-                subText="3 templates"
-                isSelected
-                counter={2}
-                className="mb-2"
-              />
-              <SelectionModal.Category
-                name="Project 2"
-                subText="7 templates"
-                isSelected={false}
-                className="mb-2"
-              />
-              <SelectionModal.Category
-                name="Project 3"
-                subText="56 templates"
-                isSelected={false}
-                counter={10}
-                className="mb-2"
-              />
-            </SelectionModal.Column>
-            <SelectionModal.Column className="px-1 pb-8">
-              <SelectionModal.ColumnHeader className="ml-2">
-                TEMPLATES
-              </SelectionModal.ColumnHeader>
-              <Checkbox
-                id="template 1"
-                // @ts-expect-error
-                label="template 1"
-                name="template 1"
-                className="text-base"
-              />
-              <Checkbox
-                id="template 2"
-                // @ts-expect-error
-                label="template 2"
-                name="template 2"
-                className="text-base"
-              />
-              <Checkbox
-                id="template 3"
-                // @ts-expect-error
-                label="template 3"
-                name="template 3"
-                className="text-base"
-              />
-              <Checkbox
-                id="template 4"
-                // @ts-expect-error
-                label="template 4"
-                name="template 4"
-                className="text-base"
-              />
-            </SelectionModal.Column>
-          </SelectionModal.Body>
-          <Modal.Footer spaceBetween>
-            <Button types={["link"]} clickHandler={action("clickHandler")}>
-              Cancel
-            </Button>
-            <Button types={["primary"]} clickHandler={action("clickHandler")}>
-              Confirm
-            </Button>
-          </Modal.Footer>
-        </SelectionModal>
-      </ModalTrigger>
-    </StoryItem>
-    <StoryItem
-      title="InputConfirmationModal"
-      description="A modal to make sure you are really sure that you want to do something."
-    >
-      <ModalTrigger>
-        <InputConfirmationModal
-          introTitle="Delete templates"
-          confirmTitle="Confirm deletion"
-          introBody="This template is currently being used. Any items using this template will be converted to use a custom structure. Are you sure you want to continue?"
-          confirmBody="Template deletion is permanent and cannot be undone. Please confirm you want to delete this template by typing ‘DELETE’ in the box below."
-          onConfirm={() => {}}
-        />
-      </ModalTrigger>
-    </StoryItem>
-  </div>
-);
+        </ModalTrigger>
+      </StoryItem>
+    </div>
+  );
+}
 
 Modals.parameters = {
   controls: { hideNoControlsWarning: true },

--- a/stories/components/ParticipantInfo.stories.tsx
+++ b/stories/components/ParticipantInfo.stories.tsx
@@ -1,28 +1,28 @@
-import React from 'react';
-import ParticipantInfoComponent from '../../lib/ParticipantInfo';
-import StoryItem from '../styleguide/StoryItem';
+import React from "react";
+import ParticipantInfoComponent from "../../lib/ParticipantInfo";
+import StoryItem from "../styleguide/StoryItem";
 
 export default {
-  title: 'Legacy/Participant Info',
-  component: ParticipantInfoComponent
+  title: "Legacy/Participant Info",
+  component: ParticipantInfoComponent,
 };
 
-export const ParticipantInfo = () => (
-  <div>
-    <StoryItem
-      title="Page information: Just a title"
-      description="Includes a title as a minimum"
-    >
-      <ParticipantInfoComponent
-        name="Angus Edwardson"
-        email="example@gmail.com"
-        // @ts-expect-error TS(2322): Type '{ name: string; email: string; pillboxText: ... Remove this comment to see the full error message
-        pillboxText="Assigned"
-      />
-    </StoryItem>
-  </div>
-);
-
+export function ParticipantInfo() {
+  return (
+    <div>
+      <StoryItem
+        title="Page information: Just a title"
+        description="Includes a title as a minimum"
+      >
+        <ParticipantInfoComponent
+          name="Angus Edwardson"
+          email="example@gmail.com"
+          pillboxText="Assigned"
+        />
+      </StoryItem>
+    </div>
+  );
+}
 ParticipantInfo.parameters = {
-  controls: { hideNoControlsWarning: true }
+  controls: { hideNoControlsWarning: true },
 };

--- a/stories/components/Search.stories.tsx
+++ b/stories/components/Search.stories.tsx
@@ -7,7 +7,7 @@ export default {
   component: SearchComponent,
 };
 
-export const Search = () => {
+export function Search() {
   return (
     <div>
       <StoryItem
@@ -18,7 +18,6 @@ export const Search = () => {
           <SearchComponent.Input onChange={() => {}} />
           <SearchComponent.Body>
             <SearchComponent.Options>
-              {/* @ts-expect-error */}
               <SearchComponent.ToggleFilter
                 label="SearchComponent all projects"
                 clickHandler={() => {}}
@@ -45,7 +44,7 @@ export const Search = () => {
       </StoryItem>
     </div>
   );
-};
+}
 
 Search.parameters = {
   controls: { hideNoControlsWarning: true },

--- a/stories/components/SelectionBar.stories.tsx
+++ b/stories/components/SelectionBar.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: SelectionBarComponent,
 };
 
-export const SelectionBar = () => {
+export function SelectionBar() {
   const example1selectedIds = [1, 2, 3];
   const example2selectedIds = [1, 2, 3, 4, 5, 6, 7, 8, 9];
   const type = "items";
@@ -17,7 +17,6 @@ export const SelectionBar = () => {
   return (
     <div>
       <StoryItem title="SelectionBarComponent">
-        {/* @ts-expect-error */}
         <SelectionBarComponent hasSelected={example1selectedIds.length}>
           <SelectionBarComponent.Information>
             <Button
@@ -53,7 +52,6 @@ export const SelectionBar = () => {
         title="SelectionBarComponent"
         description="fixed SelectionBarComponent"
       >
-        {/* @ts-expect-error */}
         <SelectionBarComponent hasSelected={example2selectedIds.length} fixed>
           <SelectionBarComponent.Information>
             <Button
@@ -91,7 +89,7 @@ export const SelectionBar = () => {
       </StoryItem>
     </div>
   );
-};
+}
 
 SelectionBar.parameters = {
   controls: { hideNoControlsWarning: true },

--- a/stories/components/Shortcut.stories.tsx
+++ b/stories/components/Shortcut.stories.tsx
@@ -7,42 +7,46 @@ export default {
   component: ShortcutComponent,
 };
 
-export const Shortcut = () => (
-  <div>
-    <StoryItem title="ShortcutComponent" description="A mix of Mac and Windows">
-      {/* @ts-expect-error */}
-      <ShortcutComponent name="Bold" styleClass="shortcut__bold" mac>
-        <ShortcutIcon>⌘</ShortcutIcon>
-        <ShortcutIcon>b</ShortcutIcon>
-      </ShortcutComponent>
-      <ShortcutComponent name="Italicize" styleClass="shortcut__italic">
-        <ShortcutIcon>Ctrl</ShortcutIcon>
-        <ShortcutIcon>i</ShortcutIcon>
-      </ShortcutComponent>
-      {/* @ts-expect-error */}
-      <ShortcutComponent name="Underline" styleClass="shortcut__underline" mac>
-        <ShortcutIcon>⌘</ShortcutIcon>
-        <ShortcutIcon>u</ShortcutIcon>
-      </ShortcutComponent>
-      <ShortcutComponent name="Apply Heading style [1-6]">
-        <ShortcutIcon>Ctrl</ShortcutIcon>
-        <ShortcutIcon>Alt</ShortcutIcon>
-        <ShortcutIcon>1-6</ShortcutIcon>
-      </ShortcutComponent>
-      {/* @ts-expect-error */}
-      <ShortcutComponent name="A shortcut" mac>
-        <ShortcutIcon>⌘</ShortcutIcon>
-        <ShortcutIcon>Option</ShortcutIcon>
-        <ShortcutIcon>G</ShortcutIcon>
-      </ShortcutComponent>
-      {/* @ts-expect-error */}
-      <ShortcutComponent name="A single button!" mac>
-        <ShortcutIcon>⇥</ShortcutIcon>
-      </ShortcutComponent>
-    </StoryItem>
-  </div>
-);
-
+export function Shortcut() {
+  return (
+    <div>
+      <StoryItem
+        title="ShortcutComponent"
+        description="A mix of Mac and Windows"
+      >
+        <ShortcutComponent name="Bold" styleClass="shortcut__bold" mac>
+          <ShortcutIcon>⌘</ShortcutIcon>
+          <ShortcutIcon>b</ShortcutIcon>
+        </ShortcutComponent>
+        <ShortcutComponent name="Italicize" styleClass="shortcut__italic">
+          <ShortcutIcon>Ctrl</ShortcutIcon>
+          <ShortcutIcon>i</ShortcutIcon>
+        </ShortcutComponent>
+        <ShortcutComponent
+          name="Underline"
+          styleClass="shortcut__underline"
+          mac
+        >
+          <ShortcutIcon>⌘</ShortcutIcon>
+          <ShortcutIcon>u</ShortcutIcon>
+        </ShortcutComponent>
+        <ShortcutComponent name="Apply Heading style [1-6]">
+          <ShortcutIcon>Ctrl</ShortcutIcon>
+          <ShortcutIcon>Alt</ShortcutIcon>
+          <ShortcutIcon>1-6</ShortcutIcon>
+        </ShortcutComponent>
+        <ShortcutComponent name="A shortcut" mac>
+          <ShortcutIcon>⌘</ShortcutIcon>
+          <ShortcutIcon>Option</ShortcutIcon>
+          <ShortcutIcon>G</ShortcutIcon>
+        </ShortcutComponent>
+        <ShortcutComponent name="A single button!" mac>
+          <ShortcutIcon>⇥</ShortcutIcon>
+        </ShortcutComponent>
+      </StoryItem>
+    </div>
+  );
+}
 Shortcut.parameters = {
   controls: { hideNoControlsWarning: true },
 };

--- a/stories/components/Tabs.stories.tsx
+++ b/stories/components/Tabs.stories.tsx
@@ -54,7 +54,6 @@ function TabsStory({ tabs, dragSide, dragIndex, editable }: any) {
                       </button>
                     ) : (
                       <TabsComponent.TabNameForm
-                        // @ts-expect-error
                         tab={t}
                         className={`${buttonClasses}`}
                         setActiveTab={(e: any) => {
@@ -114,11 +113,11 @@ export default {
   },
 };
 
-export const Tabs = (args: any) => {
+export function Tabs(args: any) {
   const tabs = [...Array(args.tabsNumber).keys()].map(() => ({
     id: v4(),
     name: faker.commerce.productName(),
   }));
 
   return <TabsStory tabs={tabs} {...args} />;
-};
+}

--- a/stories/components/TopBar.stories.tsx
+++ b/stories/components/TopBar.stories.tsx
@@ -28,7 +28,6 @@ export const Topbar = () => (
       description="TopBar is the top bar used throughout the whole site, can add a fixed attribute to fix it to the top."
     >
       <TopBar>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; left: true; xs: numbe... Remove this comment to see the full error message */}
         <TopBarContent left xs={10} md={5}>
           <TopBarCell>
             <Icon
@@ -47,7 +46,6 @@ export const Topbar = () => (
             </Button>
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; right: true; xs: numb... Remove this comment to see the full error message */}
         <TopBarContent right xs={2} md={4}>
           <TopBarCell>
             <AvatarGroup maximum={2}>
@@ -73,7 +71,6 @@ export const Topbar = () => (
             />
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: string; center: true; xs: number... Remove this comment to see the full error message */}
         <TopBarContent center xs={12} md={3}>
           Centered content
         </TopBarContent>
@@ -81,7 +78,6 @@ export const Topbar = () => (
     </StoryItem>
     <StoryItem title="TopBar dark" description="TopBar with the dark theme.">
       <TopBar useDarkTheme>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; left: true; xs: numbe... Remove this comment to see the full error message */}
         <TopBarContent left xs={10} md={5}>
           <TopBarCell>
             <Icon
@@ -100,7 +96,6 @@ export const Topbar = () => (
             </Button>
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; right: true; xs: numb... Remove this comment to see the full error message */}
         <TopBarContent right xs={2} md={4}>
           <TopBarCell>
             <AvatarGroup maximum={2}>
@@ -126,7 +121,6 @@ export const Topbar = () => (
             />
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: string; center: true; xs: number... Remove this comment to see the full error message */}
         <TopBarContent center xs={12} md={3}>
           Centered content
         </TopBarContent>
@@ -138,7 +132,6 @@ export const Topbar = () => (
       description="TopBar with the light grey theme."
     >
       <TopBar useLightGreyTheme>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; left: true; xs: numbe... Remove this comment to see the full error message */}
         <TopBarContent left xs={10} md={5}>
           <TopBarCell>
             <Icon
@@ -157,7 +150,6 @@ export const Topbar = () => (
             </Button>
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element; right: true; xs: number... Remove this comment to see the full error message */}
         <TopBarContent right xs={2} md={4}>
           <TopBarCell bordered>
             <ButtonIcon
@@ -169,7 +161,6 @@ export const Topbar = () => (
             />
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: string; center: true; xs: number... Remove this comment to see the full error message */}
         <TopBarContent center xs={12} md={3}>
           Centered content
         </TopBarContent>
@@ -181,7 +172,6 @@ export const Topbar = () => (
       description="Example of the TopBar used on the app."
     >
       <TopBar>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; left: true; xs: numbe... Remove this comment to see the full error message */}
         <TopBarContent left xs={10} md={10}>
           <TopBarCell>
             <Logo />
@@ -205,14 +195,12 @@ export const Topbar = () => (
             </Navigation>
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; right: true; xs: numb... Remove this comment to see the full error message */}
         <TopBarContent right xs={2} md={2}>
           <TopBarCell>
             <Search className="top-bar__search-dropdown">
               <Search.Input onChange={() => {}} />
               <Search.Body>
                 <Search.Options>
-                  {/* @ts-expect-error TS(2741): Property 'displayChecked' is missing in type '{ la... Remove this comment to see the full error message */}
                   <Search.ToggleFilter
                     label="Search all projects"
                     clickHandler={() => {}}
@@ -270,7 +258,6 @@ export const Topbar = () => (
           </NotificationBar>
         }
       >
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; left: true; xs: numbe... Remove this comment to see the full error message */}
         <TopBarContent left xs={10} md={10}>
           <TopBarCell>
             <Logo />
@@ -294,14 +281,12 @@ export const Topbar = () => (
             </Navigation>
           </TopBarCell>
         </TopBarContent>
-        {/* @ts-expect-error TS(2322): Type '{ children: Element[]; right: true; xs: numb... Remove this comment to see the full error message */}
         <TopBarContent right xs={2} md={2}>
           <TopBarCell>
             <Search className="top-bar__search-dropdown">
               <Search.Input onChange={() => {}} />
               <Search.Body>
                 <Search.Options>
-                  {/* @ts-expect-error TS(2741): Property 'displayChecked' is missing in type '{ la... Remove this comment to see the full error message */}
                   <Search.ToggleFilter
                     label="Search all projects"
                     clickHandler={() => {}}

--- a/stories/components/images/ImageLoader.stories.tsx
+++ b/stories/components/images/ImageLoader.stories.tsx
@@ -7,31 +7,35 @@ export default {
   component: ImageLoaderComponent,
 };
 
-export const ImageLoader = () => (
-  <div>
-    <StoryItem
-      title="Image loaders"
-      description="The image loader adds visual ques for states such as loading, loaded and failures for images."
-    >
-      <Row>
-        <Col xs={6}>
-          <ImageLoaderComponent
-            src="https://fillmurray.com/g/400/400"
-            alt="Fill Murray"
-            preLoadedStyles={{ minHeight: "400px" }}
-          />
-        </Col>
-        <Col xs={6}>
-          <ImageLoaderComponent
-            src=""
-            alt="a failed image"
-            preLoadedStyles={{ minHeight: "400px" }}
-          />
-        </Col>
-      </Row>
-    </StoryItem>
-  </div>
-);
+export function ImageLoader() {
+  return (
+    <div>
+      <StoryItem
+        title="Image loaders"
+        description="The image loader adds visual ques for states such as loading, loaded and failures for images."
+      >
+        <Row>
+          <Col xs={6}>
+            <ImageLoaderComponent
+              // @ts-expect-error
+              src="https://fillmurray.com/g/400/400"
+              alt="Fill Murray"
+              preLoadedStyles={{ minHeight: "400px" }}
+            />
+          </Col>
+          <Col xs={6}>
+            <ImageLoaderComponent
+              // @ts-expect-error
+              src=""
+              alt="a failed image"
+              preLoadedStyles={{ minHeight: "400px" }}
+            />
+          </Col>
+        </Row>
+      </StoryItem>
+    </div>
+  );
+}
 
 ImageLoader.parameters = {
   controls: { hideNoControlsWarning: true },


### PR DESCRIPTION
### 💬 Description
Legacy tests were broken on webapp, after some digging it was because typescript was not compiling due to our types being broken on GUI. Turns out we never had `@types/react` installed on either, and now react 18 is a bit more strict with child types it caused a load of issues.

Installing types/react caused a load of type errors, partly due to some inferrance from prop-types, so I've removed all prop types, then it had an issue with a few class based components, rather than ignoring the errors i've just refactored these to be functional. 

So the good news is we've cleared out a load of `@ts-expect-errors` by adding this types package, and refactored some older components. 

Bad news this is a massive pr, but its just unavoidable with sweeping changes like this. best thing to do is to pull it down and test locally
