### PR TITLE
fix checktoggle not checking after refactor

### DIFF
--- a/lib/CheckToggle/index.tsx
+++ b/lib/CheckToggle/index.tsx
@@ -71,7 +71,7 @@ export function CheckToggle({
         <input
           data-testid={id}
           onChange={onClickHandler}
-          checked={checked}
+          checked={isChecked}
           type="checkbox"
           id={id}
           className="toggle-switch toggle-switch--inline"


### PR DESCRIPTION
### 💬 Description
We need to check our own checked variable, rather than the checked prop