### PR TITLE
🐛  GC-1464 - On window resize ensure resized element shrinks too

### DIFF
--- a/lib/Resizable/index.tsx
+++ b/lib/Resizable/index.tsx
@@ -111,9 +111,16 @@ export function Resizable(props: PropsWithChildren<ResizableProps>) {
 
   useEffect(() => {
     doResize(rememberPosition ? lastPosition : initialWidth);
-
-    // remember to remove global listeners on dismount
+    // remember to remove global listeners on unmounting
     return () => stopDrag();
+  }, []);
+
+  useEffect(() => {
+    const handeWindowResize = () => doResize(getWrapperWidth() + gutterSize);
+    window.addEventListener("resize", handeWindowResize);
+    return () => {
+      window.removeEventListener("resize", handeWindowResize);
+    };
   }, []);
 
   return (

--- a/lib/Resizable/index.tsx
+++ b/lib/Resizable/index.tsx
@@ -40,14 +40,14 @@ export function Resizable(props: PropsWithChildren<ResizableProps>) {
     initialWidth
   );
 
-  const containerWidth = () =>
+  const getContainerWidth = () =>
     toPixels(props.containerWidth ?? document.body.offsetWidth);
 
-  const minWidth = () =>
-    toPixels(props.minResizableWidth ?? 0, containerWidth());
+  const getMinWidth = () =>
+    toPixels(props.minResizableWidth ?? 0, getContainerWidth());
 
-  const maxWidth = () =>
-    toPixels(props.maxResizableWidth ?? "100%", containerWidth());
+  const getMaxWidth = () =>
+    toPixels(props.maxResizableWidth ?? "100%", getContainerWidth());
 
   const getWrapperWidth = () =>
     toPixels(resizeWrapperRef.current?.style.width ?? 0);
@@ -56,7 +56,7 @@ export function Resizable(props: PropsWithChildren<ResizableProps>) {
     if (resizeWrapperRef.current === null) return;
 
     const newWidth =
-      keepValueWithinRange(value, minWidth(), maxWidth()) - gutterSize;
+      keepValueWithinRange(value, getMinWidth(), getMaxWidth()) - gutterSize;
 
     resizeWrapperRef.current.style.width = `${newWidth}px`;
     setLastPosition(newWidth);


### PR DESCRIPTION
### 💬 Description

Resolves the issue where resizing the browser to a size smaller than that of the resized element would make the page unusable because the resized element consumes the screen.

https://www.loom.com/share/93fd6e6d0e034227b95c71ab7a5979ba
