### PR TITLE
FSB-6080 Remove alwaysListen prop from comment boundary click watcher

### DIFF
--- a/lib/Comment/CommentDeleteConfirmation.tsx
+++ b/lib/Comment/CommentDeleteConfirmation.tsx
@@ -17,7 +17,7 @@ function CommentDeleteConfirmation({
   };
 
   return isDeleting ? (
-    <BoundaryClickWatcher outsideClickHandler={closeAndCancel} alwaysListen>
+    <BoundaryClickWatcher outsideClickHandler={closeAndCancel}>
       <ConfirmationOverlay
         className="comment-delete-confirmation"
         show={isDeleting}


### PR DESCRIPTION
### 💬 Description
After some investigation with @timbryandev we found that;
- The delete comment confirmation overlay _is being shown_ but is then immediately hidden, so it's never seen by the user
- Clicking the delete button in the actions menu appeared to be triggering the outside click handler of the delete comment confirmation overlay, causing it to be immediately hidden
- Removing the `alwaysListen` prop from the boundary click watcher in the delete comment confirmation overlay stops it being immediately hidden
- After some discussion with @AmeeMorris we determined that the `alwaysListen` prop doesn't appear to be serving a purpose in this instance and can be safely removed