### PR TITLE
GC-3452 Control Notification Blip visibility with visible prop

### DIFF
--- a/lib/Notification/blip/NotificationBlip.tsx
+++ b/lib/Notification/blip/NotificationBlip.tsx
@@ -3,10 +3,15 @@ import cx from 'classnames';
 
 interface Props {
   children: React.ReactNode;
+  visible: boolean;
   className?: string;
 }
 
-export function NotificationBlip({ children, className }: Props) {
-  const classes = cx('notification-blip', className);
+export function NotificationBlip({ children, visible, className }: Props) {
+  const classes = cx(
+    'notification-blip',
+    visible ? 'after:opacity-1' : 'after:opacity-0',
+    className,
+  );
   return <div className={classes}>{children}</div>;
 }

--- a/stories/components/NotificationBlip.stories.tsx
+++ b/stories/components/NotificationBlip.stories.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { Button, ButtonIcon } from "../../lib";
-import { Icon } from "../../lib";
+import { ButtonIcon } from "../../lib";
 import { NotificationBlip as NotificationBlipComponent } from "../../lib/Notification/blip/NotificationBlip";
 import StoryItem from "../styleguide/StoryItem";
 
 export default {
   title: 'GUI/Notification Blip',
   component: NotificationBlipComponent,
+  args: {
+    visible: true,
+  }
 };
 
 export const NotificationBlip = (args: any) => <>
@@ -14,7 +16,7 @@ export const NotificationBlip = (args: any) => <>
     title="Notification blip"
     description="A visual indicator to inform the user they have notifications"
   >
-    <NotificationBlipComponent>
+    <NotificationBlipComponent visible={args.visible} className={args.className}>
       <ButtonIcon name={'bell'} />
     </NotificationBlipComponent>
   </StoryItem>


### PR DESCRIPTION
### 💬 Description
- Added visible prop to Notification Blip, controlling the visibility using the Tailwind opacity class
- Updated the Notification Blip story accordingly

Relates to https://github.com/Bynder/gathercontent-csr/pull/5591.
