### PR TITLE
GC-3644 fix button tertiary state styles for non white backgrounds

### DIFF
--- a/lib/src/modules/Button/ButtonTertiary/styles/buttonTertiary.scss
+++ b/lib/src/modules/Button/ButtonTertiary/styles/buttonTertiary.scss
@@ -2,17 +2,15 @@
   @apply border-neutral-90 border-solid text-neutral-20 bg-white;
 
   &:hover {
-    background-color: rgb(103 128 152 / 10%);
+    @apply bg-neutral-95;
   }
 
   &:active,
   &.gui-button-tertiary-active {
-    background-color: rgb(103 128 152 / 10%);
+    @apply bg-neutral-95;
   }
 
   &:focus {
-    background-color: rgb(103 128 152 / 20%);
-
     @apply border-neutral-20 shadow-button-tertiary-focus;
   }
 


### PR DESCRIPTION
### 💬 Description
Not a gui- class issue, but transparent background styles dont work on anything but a plain background
