### PR TITLE
🩹GC-3829 Menu items being underlined on hover

### DIFF
--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -150,6 +150,10 @@ $dropdown-status-circle-width-height: 15px !default;
 .gui-dropdown__action-link {
   color: $neutral-dark;
   text-decoration: none;
+
+  &:hover {
+    text-decoration: none;
+  }
 }
 
 .gui-dropdown__trigger-wrapper {

--- a/lib/Dropdown/styles.scss
+++ b/lib/Dropdown/styles.scss
@@ -150,6 +150,7 @@ $dropdown-status-circle-width-height: 15px !default;
 .gui-dropdown__action-link {
   color: $neutral-dark;
   text-decoration: none;
+  overflow: auto;
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
### 💬 Description

https://bynder.atlassian.net/browse/GC-3829

"Strange styling issue. Some menu items are underlined on hover, others aren’t. The example shown is the item menu.

Menu items should not be underlined on hover."