### PR TITLE
GC-3786 Wrong icon colour when resolving conversations

### DIFF
--- a/lib/Comment/CommentResolveButton.tsx
+++ b/lib/Comment/CommentResolveButton.tsx
@@ -12,7 +12,7 @@ export function CommentResolveButton({
     <div className="flex items-center ml-auto h-8">
       {resolved && (
         <span className="text-sm font-semi-bold text-green-primary inline-flex item justify-center items-center">
-          <Icon name="resolved" className="fill-primary-green mr-1" />
+          <Icon name="resolved" className="mr-1" />
           Resolved
           {onUndoResolve && userCanResolve && (
             <div className="ml-2">

--- a/lib/Comment/styles.scss
+++ b/lib/Comment/styles.scss
@@ -65,3 +65,7 @@
     @apply text-neutral-primary text-xs;
   }
 }
+
+.gui-icon--resolved path {
+  @apply fill-green-primary;
+}


### PR DESCRIPTION
The tailwind class applied inline in the component only applies to the span and doesn't filter down to the SVGs path elements.

Doing this via SCSS ensures the correct colour is applied to the whole SVG.

I'm unsure if this has always been incorrect, or if the changes happened as part of the mono/gui tailwind clash resolutions