### PR TITLE
[GC-4172] Move all GitHub Actions across to fixed versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
       - name: Get new version
         id: new-version
-        uses: martinbeentjes/npm-get-version-action@main
+        uses: martinbeentjes/npm-get-version-action@v1.3.1
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: version ${{ steps.new-version.outputs.current-version}}


### PR DESCRIPTION
### 💬 Description
As part of the Bynder adoption of GitHub Actions they have reviewed our action usage and found a few actions we don't specify a specific version which could mean those actions could get comprised and we would pull in the comprised action straight away.
